### PR TITLE
Easy installation sequece by introducing the .repos pointing to itsself.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,7 @@ cd ~/ros2/aerial_robot_base_ws
 sudo rosdep init
 rosdep update
 # install repository
-vcs import src <<EOF
-repositories:
-  aerial_robot_base:
-    type: git
-    url: 'https://github.com/ut-dragon-lab/aerial_robot_base.git'
-    version: master
-EOF
+vcs import src --input https://raw.githubusercontent.com/ut-dragon-lab/aerial_robot_base/master/aerial_robot_base.repos
 # Install depended repositories
 vcs import src < src/aerial_robot_base/aerial_robot_${ROS_DISTRO}.repos
 rosdep install -y -r --from-paths src --ignore-src --rosdistro ${ROS_DISTRO}

--- a/aerial_robot_base.repos
+++ b/aerial_robot_base.repos
@@ -1,0 +1,6 @@
+repositories:
+  aerial_robot_base:
+    type: git
+    url: "https://github.com/ut-dragon-lab/aerial_robot_base.git" 
+    version: "master"
+    local-name: "aerial_robot_base"


### PR DESCRIPTION
### What is this

Introducing [aerial_robot_base.repos](https://github.com/ut-dragon-lab/aerial_robot_base/compare/master...tongtybj:aerial_robot_base:PR/own_dependency?expand=1#diff-5c599f7213ab7356ae54f9d7e17a42ee4305c4a68d50e9690db2d24b918a3e10) that only contains itself. 
This is quite helpful for initial installation as described in `README.md`, and also for other repositories that depdend on this one.
