### PR TITLE
Use ROS based clock instead of wall time.

### DIFF
--- a/aerial_robot_core/src/aerial_robot_core.cpp
+++ b/aerial_robot_core/src/aerial_robot_core.cpp
@@ -60,7 +60,8 @@ AerialRobotCore::AerialRobotCore(rclcpp::Node::SharedPtr node) : node_(node) {
   } else {
     // create timer
     auto period = std::chrono::duration<double>(1.0 / main_rate);
-    main_timer_ = node_->create_wall_timer(period, std::bind(&AerialRobotCore::mainFunc, this));
+    main_timer_ = rclcpp::create_timer(node_, node_->get_clock(), period,
+                                       std::bind(&AerialRobotCore::mainFunc, this));
   }
 
   // // for debug

--- a/aerial_robot_simulation/launch/gazebo_launch.py
+++ b/aerial_robot_simulation/launch/gazebo_launch.py
@@ -153,6 +153,27 @@ def generate_launch_description():
         output='screen',
     )
 
+    att_controller_spawner = Node(
+        namespace= robot_name,
+        package='controller_manager',
+        executable='spawner',
+        name='spawn_att_controller',
+        output='screen',
+        arguments=[
+            'attitude_controller',
+            '--param-file', sim_param_file
+        ],
+        parameters=[{'use_sim_time': True}]
+    )
+
+    joint_state_broadcaster_spawner = Node(
+        namespace= robot_name,
+        package='controller_manager',
+        executable='spawner',
+        arguments=['joint_state_broadcaster'],
+        parameters=[{'use_sim_time': True}],
+    )
+
     ld = LaunchDescription()
     ld.add_action(world_arg)
     ld.add_action(robot_name_arg)
@@ -169,5 +190,8 @@ def generate_launch_description():
     ld.add_action(shutdown_handler)
     ld.add_action(ign_client)
     ld.add_action(clock_bridge)
-    ld.add_action(spawn_robot)   
+    ld.add_action(spawn_robot)
+    ld.add_action(joint_state_broadcaster_spawner)
+    ld.add_action(att_controller_spawner)
+
     return ld

--- a/robots/mini_quadrotor/launch/bringup_launch.py
+++ b/robots/mini_quadrotor/launch/bringup_launch.py
@@ -133,13 +133,7 @@ def generate_launch_description():
         )
     }
 
-    # --- joint state condition parameter---
-    need_js = PythonExpression([
-            # 'false' if sim=='true' or rm=='true' else 'true'
-        "'false' if '", sim, "' == 'true' or '", rm, "' == 'true' else 'true'"
-    ])
-
-    # --- rviz config path ---w
+    # --- rviz config path ---
     rviz_config = PathJoinSubstitution([
         FindPackageShare(robot_model_pkg),
         'config',
@@ -152,7 +146,8 @@ def generate_launch_description():
         executable='aerial_robot_core_node',
         name='aerial_robot_core',
         namespace=robot_ns,
-        parameters=[robot_description, robot_model_plugin_name],
+        parameters=[{'use_sim_time': sim},
+                    robot_description, robot_model_plugin_name],
         output = 'screen'
     )
 
@@ -166,12 +161,13 @@ def generate_launch_description():
         ),
         launch_arguments={
             'headless': LaunchConfiguration('headless'),
+            'rm': LaunchConfiguration('rm'),
+            'sim': LaunchConfiguration('sim'),
             'model_options': LaunchConfiguration('model_options'),
             'robot_model': LaunchConfiguration('robot_model'),
             'robot_ns': LaunchConfiguration('robot_ns'),
             'robot_model_rviz': LaunchConfiguration('robot_model_rviz'),
             'robot_description_content': robot_description_content,
-            'need_joint_state': need_js,
         }.items(),
     )
     
@@ -194,19 +190,6 @@ def generate_launch_description():
         condition=IfCondition(sim),
     )
 
-    att_controller_spawner = Node(
-        namespace= robot_ns,
-        package='controller_manager',
-        executable='spawner',
-        name='spawn_att_controller',
-        output='screen',
-        arguments=[
-            'attitude_controller',
-            '--param-file', sim_param_file
-        ],
-        condition=IfCondition(sim),
-    )
-
     ld = LaunchDescription()
     ld.add_action(headless_arg)
     ld.add_action(model_options_arg)
@@ -221,5 +204,4 @@ def generate_launch_description():
     ld.add_action(core_node)
     ld.add_action(model_launch)
     ld.add_action(sim_launch)
-    ld.add_action(att_controller_spawner)
     return ld


### PR DESCRIPTION
### What is this

To support the simulation like gazebo, it is neessary to unify the clock in both gazebo and `aerial_robot_core`.

### Details
- use `rclcpp::create_timer` instead of `node_->create_wall_timer`.
- substitude ros paramter `use_sim_time` to all nodes that need the correct clock.
- refactor `gazebo_launch.py`: move several common controller spawner nodes
- refactor `aerial_robot_model_launch.py`: directly substitude `rm` and `sim` instead of `need_js`.