### PR TITLE
[Cmake][Depndency] export rclcpp_lifecycle as the dependency of spinal

### DIFF
--- a/aerial_robot_core/CMakeLists.txt
+++ b/aerial_robot_core/CMakeLists.txt
@@ -8,7 +8,6 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(aerial_robot_model REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 

--- a/aerial_robot_model/CMakeLists.txt
+++ b/aerial_robot_model/CMakeLists.txt
@@ -8,7 +8,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # --- ament & ROS 2 packages ---
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(rosidl_typesupport_cpp REQUIRED)

--- a/aerial_robot_nerve/spinal/CMakeLists.txt
+++ b/aerial_robot_nerve/spinal/CMakeLists.txt
@@ -106,6 +106,9 @@ install(
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_include_directories(include/My_Lib)
 
-ament_export_dependencies(rosidl_default_runtime)
+ament_export_dependencies(rosidl_default_runtime
+                          std_msgs
+                          geometry_msgs
+                          rclcpp_lifecycle)
 
 ament_package()


### PR DESCRIPTION
### What is this

`rclcpp_lifecycle` is only used in package `spinal`;  however since it was not correctly exported, we had to import (by `find_package`) in the downstream packages like `aerial_robot_model`.
I have fix this problem by refactor `ament_export_dependencies` command in package `spinal`.