### PR TITLE
[ROS Parameter] the correct way to declare and handle the default value for ros parameters

### DIFF
--- a/aerial_robot_core/src/aerial_robot_core.cpp
+++ b/aerial_robot_core/src/aerial_robot_core.cpp
@@ -41,12 +41,11 @@
 using namespace std::chrono_literals;
 
 AerialRobotCore::AerialRobotCore(rclcpp::Node::SharedPtr node) : node_(node) {
-  // declare parameters
-  node_->declare_parameter<bool>("param_verbose", true);
-  node_->declare_parameter<double>("main_rate", 1.0);
   // get parameters
-  bool param_verbose = node_->get_parameter("param_verbose").as_bool();
-  double main_rate = node_->get_parameter("main_rate").as_double();
+  bool param_verbose;
+  node_->get_parameter_or("param_verbose", param_verbose, false);
+  double main_rate;
+  node_->get_parameter_or("main_rate", main_rate, 1.0);
 
   robot_model_ros_ = std::make_shared<aerial_robot_model::RobotModelRos>(node_);
   auto robot_model = robot_model_ros_->getRobotModel();

--- a/aerial_robot_core/src/aerial_robot_core_node.cpp
+++ b/aerial_robot_core/src/aerial_robot_core_node.cpp
@@ -41,6 +41,7 @@ int main(int argc, char* argv[]) {
 
   rclcpp::NodeOptions options;
   options.allow_undeclared_parameters(true);
+  options.automatically_declare_parameters_from_overrides(true);
   auto core_node = std::make_shared<rclcpp::Node>("aerial_robot_core", options);
 
   auto core = std::make_shared<AerialRobotCore>(core_node);

--- a/aerial_robot_model/src/model/base_model/robot_model.cpp
+++ b/aerial_robot_model/src/model/base_model/robot_model.cpp
@@ -94,8 +94,10 @@ void RobotModel::getParamFromRos() {
 void RobotModel::kinematicsInit() {
   // URDF
   std::string urdf_xml;
-  node_->declare_parameter<std::string>("robot_description", "");
-  node_->get_parameter("robot_description", urdf_xml);
+  if(!node_->get_parameter("robot_description", urdf_xml)) {
+    RCLCPP_ERROR(LOGGER, "Failed to get robot desciription parameter");
+    return;
+  }
 
   if (!model_.initString(urdf_xml)) {
     RCLCPP_ERROR(LOGGER, "Failed to parse URDF from parameter");

--- a/aerial_robot_model/src/model/base_model/robot_model_ros.cpp
+++ b/aerial_robot_model/src/model/base_model/robot_model_ros.cpp
@@ -40,12 +40,10 @@ RobotModelRos::RobotModelRos(rclcpp::Node::SharedPtr node)
       // pluginlib: package name, base class
       robot_model_loader_("aerial_robot_model", "aerial_robot_model::RobotModel") {
   // 1) Declare & read the tf_prefix parameter
-  node_->declare_parameter<std::string>("tf_prefix", "");
-  node_->get_parameter("tf_prefix", tf_prefix_);
+  node_->get_parameter_or<std::string>("tf_prefix", tf_prefix_, "");
 
   // 2) Load the robot‐model plugin
   std::string plugin_name;
-  node_->declare_parameter<std::string>("robot_model_plugin_name", "");
   if (node_->get_parameter("robot_model_plugin_name", plugin_name)) {
     try {
       robot_model_ = robot_model_loader_.createSharedInstance(plugin_name);
@@ -85,9 +83,13 @@ RobotModelRos::RobotModelRos(rclcpp::Node::SharedPtr node)
   }
 
   // 5) Advertise the add_extra_module service
-  add_extra_module_srv_ = node_->create_service<aerial_robot_model::srv::AddExtraModule>(
-      "add_extra_module", std::bind(&RobotModelRos::addExtraModuleCallback, this, std::placeholders::_1,
-                                    std::placeholders::_2, std::placeholders::_3));
+  add_extra_module_srv_
+    = node_->create_service<aerial_robot_model::srv::AddExtraModule>
+    ("add_extra_module",
+     std::bind(&RobotModelRos::addExtraModuleCallback, this,
+               std::placeholders::_1,
+               std::placeholders::_2,
+               std::placeholders::_3));
 }
 
 void RobotModelRos::jointStateCallback(const sensor_msgs::msg::JointState::SharedPtr msg) {


### PR DESCRIPTION
### What is this 

The correct way of ros parameter declaration and initialization.

### Details

Recently I created a PR about ros parameter declaration #12 .
However, after a carefully investigation, I found it does not perfectly match our system.
So I refactor again. 
The new rule is as follows:
- Call `options.automatically_declare_parameters_from_overrides(true);` to allow the automatically ros paramter declare if there is the description in launch or yaml files.
   - Actaully, we cannot call `node_->declare_parameter()` if we call  `options.automatically_declare_parameters_from_overrides(true);` since it will be duplicated decalration as reported in #12.
- Call `node_->get_parameter_or()` instead of `node_->get_parameter()` to effectively have the default value for all parameters.
  - **Do not** call `declare_parameter` anymore
  
