### PR TITLE
Fix build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 source /opt/ros/${ROS_DISTRO}/setup.bash
 sudo apt update
 # Install Python tools
-sudo apt install -y python3-vcstool python3-colcon-common-extensions
+sudo apt install -y python3-vcstool python3-colcon-common-extensions python3-colcon-clean
 # Install format tools
 sudo apt-get install clang-format
 pip install pre-commit

--- a/aerial_robot_model/CMakeLists.txt
+++ b/aerial_robot_model/CMakeLists.txt
@@ -100,10 +100,13 @@ target_include_directories(aerial_robot_model_ros
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
     )
-rosidl_target_interfaces(aerial_robot_model_ros
+rosidl_get_typesupport_target(cpp_typesupport_target
   ${PROJECT_NAME}
   "rosidl_typesupport_cpp"
-)  
+)
+target_link_libraries(aerial_robot_model_ros
+  "${cpp_typesupport_target}"
+)
 
 # --- robot_model plugin ----------------------------------------
 add_library(robot_model_plugin SHARED

--- a/aerial_robot_nerve/spinal/CMakeLists.txt
+++ b/aerial_robot_nerve/spinal/CMakeLists.txt
@@ -68,7 +68,7 @@ add_library(spinal_math
   ${SPINAL_DIRS}/math/vector2.cpp
   ${SPINAL_DIRS}/math/vector3.cpp
   ${SPINAL_DIRS}/math/quaternion.cpp
-  # ${SPINAL_DIRS}/math/location.cpp
+  ${SPINAL_DIRS}/math/location.cpp
   )
 
 

--- a/aerial_robot_nerve/spinal/mcu_project/lib/My_Lib/math/vector2.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/My_Lib/math/vector2.h
@@ -25,7 +25,7 @@
  *          18-12-2003
  *          06-06-2004
  *
- * © 2003, This code is provided "as is" and you can use it freely as long as
+ * Copyright (C) 2003, This code is provided "as is" and you can use it freely as long as
  * credit is given to Bill Perone in the application it is used in
  ****************************************/
 

--- a/aerial_robot_nerve/spinal/mcu_project/lib/My_Lib/math/vector3.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/My_Lib/math/vector3.h
@@ -26,7 +26,7 @@
  *          18-12-2003
  *          06-06-2004
  *
- * � 2003, This code is provided "as is" and you can use it freely as long as
+ * Copyright (C) 2003, This code is provided "as is" and you can use it freely as long as
  * credit is given to Bill Perone in the application it is used in
  *
  * Notes:

--- a/aerial_robot_nerve/spinal/mcu_project/lib/My_Lib/math/vector3.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/My_Lib/math/vector3.h
@@ -26,7 +26,7 @@
  *          18-12-2003
  *          06-06-2004
  *
- * © 2003, This code is provided "as is" and you can use it freely as long as
+ * ï¿½ 2003, This code is provided "as is" and you can use it freely as long as
  * credit is given to Bill Perone in the application it is used in
  *
  * Notes:
@@ -53,6 +53,7 @@
 #include <float.h>
 #include <math.h>
 #include <string.h>
+#include "rotations.h"
 
 #if MATH_CHECK_INDEXES
 #include <assert.h>


### PR DESCRIPTION
### WHAT IS THIS
Fix inclusion errors that occur during build process on my system. In my view, the build process should not work currently and I don't know why it works for on other machines. But including the correct header files and fixing the `CMakeLists.txt` for the `aerial_robot_nerve` package should be correct. Also included the `python3-colcon-clean` to enable cleaning the workspace.

P.S.: The fixes were proposed by ChatAI.

P.P.S.: I also submitted a PR to the `executive_smach` repo since in their code they have an outdated interface to `setuptools`. This causes warnings during the build process.
With this PR (and the manual changes to the `smach` repo) the build process works cleanly and without warnings! 