### PR TITLE
Revise pre-commit & clang-format 

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,0 @@
-# .clang-format
-BasedOnStyle: Google   # Google style base
-IndentWidth: 2         # Indent each block by 2 spaces
-ColumnLimit: 120       # Maximum line length is 120 characters.
-UseTab: Never          # Never insert literal tab characters
-SortIncludes: false #Never change the order of include

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,11 @@ repos:
     hooks:
       - id: clang-format
         name: clang-format
-        entry: clang-format -i
+        entry: clang-format -i --style=file:pre-commit/.clang-format
+        language: system
+        files: \.(cpp|cc|h|hpp)$
+      - id: capitalize-comments
+        name: Capitalize C++ comments
+        entry: python pre-commit/capitalize_cpp_comments.py
         language: system
         files: \.(cpp|cc|h|hpp)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,66 @@
 # .pre-commit-config.yaml
 repos:
+  # Python
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+      - id: black
+        language: python
+        args: [--line-length=120]
+
   - repo: local
     hooks:
+      # C++
       - id: clang-format
         name: clang-format
         entry: clang-format -i --style=file:pre-commit/.clang-format
         language: system
         files: \.(cpp|cc|h|hpp)$
-      - id: capitalize-comments
+
+      - id: capitalize-cpp-comments
         name: Capitalize C++ comments
         entry: python pre-commit/capitalize_cpp_comments.py
         language: system
         files: \.(cpp|cc|h|hpp)$
+
+      # Python
+      - id: capitalize-python-comments
+        name: Capitalize Python comments
+        entry: python pre-commit/capitalize_python_comments.py
+        language: system
+        files: \.py$
+
+      # YAML
+      - id: capitalize-yaml-comments
+        name: Capitalize YAML comments
+        entry: python pre-commit/capitalize_yaml_comments.py
+        language: system
+        files: \.(yaml|yml)$
+
+      # Txt
+      - id: capitalize-txt-comments
+        name: Capitalize TXT first lines
+        entry: python pre-commit/capitalize_txt_comments.py
+        language: system
+        files: \.txt$
+
+      # XML
+      - id: capitalize-xml-comments
+        name: Capitalize XML comments
+        entry: python pre-commit/capitalize_xml_comments.py
+        language: system
+        files: \.xml$
+
+      # Xacro
+      - id: capitalize-xacro-comments
+        name: Capitalize Xacro comments
+        entry: python pre-commit/capitalize_xacro_comments.py
+        language: system
+        files: \.xacro$
+
+      # Markdown
+      - id: capitalize-markdown-comments
+        name: Capitalize Markdown HTML comments
+        entry: python pre-commit/capitalize_md_comments.py
+        language: system
+        files: \.(md|markdown)$

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ sudo apt update
 # Install Python tools
 sudo apt install -y python3-vcstool python3-colcon-common-extensions python3-colcon-clean gdb clang-format
 # Install format tools
-pip install pre-commit
+pip install pre-commit black
 # Create workspace
 mkdir -p ~/ros2/aerial_robot_base_ws/src
 cd ~/ros2/aerial_robot_base_ws

--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@
 source /opt/ros/${ROS_DISTRO}/setup.bash
 sudo apt update
 # Install Python tools
-sudo apt install -y python3-vcstool python3-colcon-common-extensions python3-colcon-clean
+sudo apt install -y python3-vcstool python3-colcon-common-extensions python3-colcon-clean gdb clang-format
 # Install format tools
-sudo apt-get install clang-format
 pip install pre-commit
 # Create workspace
 mkdir -p ~/ros2/aerial_robot_base_ws/src

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 source /opt/ros/${ROS_DISTRO}/setup.bash
 sudo apt update
 # Install Python tools
-sudo apt install -y python3-vcstool python3-colcon-common-extensions
+sudo apt install -y python3-vcstool python3-colcon-common-extensions python3-colcon-clean
 # Install format tools
 sudo apt-get install clang-format
 pip install pre-commit

--- a/aerial_robot_core/launch/joy_stick_launch.py
+++ b/aerial_robot_core/launch/joy_stick_launch.py
@@ -11,36 +11,36 @@ _ARGS = [
     ("robot_ns", "/", "Namespace for all robot nodes"),
 ]
 
+
 def generate_launch_description():
     # ------------------------------------------------------------------
     # 1.  Declare CLI-overridable arguments
     # ------------------------------------------------------------------
     declared_args = [
         DeclareLaunchArgument(
-            name,
-            default_value=default_value,
-            description=description,
-            **({"choices": choices[0]} if choices else {})
+            name, default_value=default_value, description=description, **({"choices": choices[0]} if choices else {})
         )
         for name, default_value, description, *choices in _ARGS
     ]
 
     # Resolve / Read at launch time (NOT AT IMPORT TIME)
-    robot_ns        = LaunchConfiguration("robot_ns")
+    robot_ns = LaunchConfiguration("robot_ns")
 
     # ------------------------------------------------------------------
     # 2.  Nodes
     # ------------------------------------------------------------------
     joy_node = Node(
-        package='joy',
-        executable='joy_node',
-        name='joy_node',
+        package="joy",
+        executable="joy_node",
+        name="joy_node",
         namespace=robot_ns,
-        output='screen',
-        parameters=[{
-            'dev': '/dev/input/js0',
-            'coalesce_interval': 0.025,
-        }]
+        output="screen",
+        parameters=[
+            {
+                "dev": "/dev/input/js0",
+                "coalesce_interval": 0.025,
+            }
+        ],
     )
 
     # ------------------------------------------------------------------

--- a/aerial_robot_core/launch/joy_stick_launch.py
+++ b/aerial_robot_core/launch/joy_stick_launch.py
@@ -1,27 +1,55 @@
-import launch
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
-def generate_launch_description():
-    robot_name = LaunchConfiguration('robot_name')
 
-    return LaunchDescription([
+# ---------------------------------------------------------------------------
+# Argument declarations  (name, default, description, (optional) choices)
+# ---------------------------------------------------------------------------
+_ARGS = [
+    ("robot_ns", "/", "Namespace for all robot nodes"),
+]
+
+def generate_launch_description():
+    # ------------------------------------------------------------------
+    # 1.  Declare CLI-overridable arguments
+    # ------------------------------------------------------------------
+    declared_args = [
         DeclareLaunchArgument(
-            'robot_name',
-            default_value='/',
-            description='Namespace for the robot'
-        ),
-        Node(
-            package='joy',
-            executable='joy_node',
-            name='joy_node',
-            namespace=robot_name,
-            output='screen',
-            parameters=[{
-                'dev': '/dev/input/js0',
-                'coalesce_interval': 0.025,
-            }]
+            name,
+            default_value=default_value,
+            description=description,
+            **({"choices": choices[0]} if choices else {})
         )
-    ])
+        for name, default_value, description, *choices in _ARGS
+    ]
+
+    # Resolve / Read at launch time (NOT AT IMPORT TIME)
+    robot_ns        = LaunchConfiguration("robot_ns")
+
+    # ------------------------------------------------------------------
+    # 2.  Nodes
+    # ------------------------------------------------------------------
+    joy_node = Node(
+        package='joy',
+        executable='joy_node',
+        name='joy_node',
+        namespace=robot_ns,
+        output='screen',
+        parameters=[{
+            'dev': '/dev/input/js0',
+            'coalesce_interval': 0.025,
+        }]
+    )
+
+    # ------------------------------------------------------------------
+    # 3.  Assemble LaunchDescription
+    # ------------------------------------------------------------------
+    ld = LaunchDescription()
+
+    for arg in declared_args:
+        ld.add_action(arg)
+
+    ld.add_action(joy_node)
+    return ld

--- a/aerial_robot_core/package.xml
+++ b/aerial_robot_core/package.xml
@@ -14,8 +14,8 @@
   <depend>aerial_robot_estimation</depend>
   <!-- <depend>aerial_robot_control</depend> -->
   <exec_depend>ros2launch</exec_depend>
-  <exec_depend>ament_cmake_python</exec_depend>
 
+  <exec_depend>ament_cmake_python</exec_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/aerial_robot_core/scripts/keyboard_command.py
+++ b/aerial_robot_core/scripts/keyboard_command.py
@@ -46,20 +46,20 @@ def printMsg(msg_str, msg_len=50):
 
 class KeyboardCommandNode(Node):
     def __init__(self):
-        super().__init__('keyboard_command')
+        super().__init__("keyboard_command")
         self.declare_parameter("robot_ns", "")
         self.robot_ns = self.get_parameter("robot_ns").value
         if not self.robot_ns:
             self.robot_ns = ""
 
         ns = self.robot_ns + "/teleop_command"
-        self.land_pub = self.create_publisher(Empty, ns + '/land', 1)
-        self.halt_pub = self.create_publisher(Empty, ns + '/halt', 1)
-        self.start_pub = self.create_publisher(Empty, ns + '/start', 1)
-        self.takeoff_pub = self.create_publisher(Empty, ns + '/takeoff', 1)
-        self.force_landing_pub = self.create_publisher(Empty, ns + '/force_landing', 1)
-        self.nav_pub = self.create_publisher(FlightNav, self.robot_ns + '/uav/nav', 1)
-        self.motion_start_pub = self.create_publisher(Empty, 'task_start', 1)
+        self.land_pub = self.create_publisher(Empty, ns + "/land", 1)
+        self.halt_pub = self.create_publisher(Empty, ns + "/halt", 1)
+        self.start_pub = self.create_publisher(Empty, ns + "/start", 1)
+        self.takeoff_pub = self.create_publisher(Empty, ns + "/takeoff", 1)
+        self.force_landing_pub = self.create_publisher(Empty, ns + "/force_landing", 1)
+        self.nav_pub = self.create_publisher(FlightNav, self.robot_ns + "/uav/nav", 1)
+        self.motion_start_pub = self.create_publisher(Empty, "task_start", 1)
 
         self.declare_parameter("xy_vel", 0.2)
         self.declare_parameter("z_vel", 0.2)
@@ -79,65 +79,65 @@ class KeyboardCommandNode(Node):
             key = getKey()
             output = ""
 
-            if key == 'l':
+            if key == "l":
                 self.land_pub.publish(Empty())
-                output = "send land command"
-            elif key == 'r':
+                output = "sent land command"
+            elif key == "r":
                 self.start_pub.publish(Empty())
-                output = "send motor-arming command"
-            elif key == 'h':
+                output = "sent motor-arming command"
+            elif key == "h":
                 self.halt_pub.publish(Empty())
-                output = "send motor-disarming (halt) command"
-            elif key == 'f':
+                output = "sent motor-disarming (halt) command"
+            elif key == "f":
                 self.force_landing_pub.publish(Empty())
-                output = "send force landing command"
-            elif key == 't':
+                output = "sent force landing command"
+            elif key == "t":
                 self.takeoff_pub.publish(Empty())
-                output = "send takeoff command"
-            elif key == 'x':
+                output = "sent takeoff command"
+            elif key == "x":
                 self.motion_start_pub.publish(Empty())
-                output = "send task-start command"
-            elif key == 'w':
+                output = "sent task-start command"
+            elif key == "w":
                 nav_msg.pos_xy_nav_mode = FlightNav.VEL_MODE
                 nav_msg.target_vel_x = self.xy_vel
                 self.nav_pub.publish(nav_msg)
-                output = "send +x vel command"
-            elif key == 's':
+                output = "sent +x vel command"
+            elif key == "s":
                 nav_msg.pos_xy_nav_mode = FlightNav.VEL_MODE
                 nav_msg.target_vel_x = -self.xy_vel
                 self.nav_pub.publish(nav_msg)
-                output = "send -x vel command"
-            elif key == 'a':
+                output = "sent -x vel command"
+            elif key == "a":
                 nav_msg.pos_xy_nav_mode = FlightNav.VEL_MODE
                 nav_msg.target_vel_y = self.xy_vel
                 self.nav_pub.publish(nav_msg)
-                output = "send +y vel command"
-            elif key == 'd':
+                output = "sent +y vel command"
+            elif key == "d":
                 nav_msg.pos_xy_nav_mode = FlightNav.VEL_MODE
                 nav_msg.target_vel_y = -self.xy_vel
                 self.nav_pub.publish(nav_msg)
-                output = "send -y vel command"
-            elif key == 'q':
+                output = "sent -y vel command"
+            elif key == "q":
                 nav_msg.yaw_nav_mode = FlightNav.VEL_MODE
                 nav_msg.target_omega_z = self.yaw_vel
                 self.nav_pub.publish(nav_msg)
-                output = "send +yaw vel command"
-            elif key == 'e':
+                output = "sent +yaw vel command"
+            elif key == "e":
                 nav_msg.yaw_nav_mode = FlightNav.VEL_MODE
                 nav_msg.target_omega_z = -self.yaw_vel
                 self.nav_pub.publish(nav_msg)
-                output = "send -yaw vel command"
-            elif key == '[':
+                output = "sent -yaw vel command"
+            elif key == "[":
                 nav_msg.pos_z_nav_mode = FlightNav.VEL_MODE
                 nav_msg.target_vel_z = self.z_vel
                 self.nav_pub.publish(nav_msg)
-                output = "send +z vel command"
-            elif key == ']':
+                output = "sent +z vel command"
+            elif key == "]":
                 nav_msg.pos_z_nav_mode = FlightNav.VEL_MODE
                 nav_msg.target_vel_z = -self.z_vel
                 self.nav_pub.publish(nav_msg)
-                output = "send -z vel command"
-            elif key == '\x03':  # Ctrl+C
+                output = "sent -z vel command"
+            elif key == "\x03":  # Ctrl+C
                 break
 
             printMsg(output)
@@ -157,5 +157,5 @@ def main():
         node.destroy_node()
         rclpy.shutdown()
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/aerial_robot_estimation/include/aerial_robot_estimation/state_estimation.h
+++ b/aerial_robot_estimation/include/aerial_robot_estimation/state_estimation.h
@@ -1,4 +1,4 @@
-// -*- mode: c++ -*-
+// -*- Mode: c++ -*-
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
@@ -35,7 +35,7 @@
 
 #pragma once
 
-/* common utility */
+/* Common utility */
 #include <deque>
 #include <fnmatch.h>
 #include <kdl/frames.hpp>
@@ -44,237 +44,247 @@
 #include <kalman_filter/kf_base_plugin.h>
 #include <aerial_robot_model/model/aerial_robot_model.h>
 
-/* ros API */
+/* ROS API */
 #include <rclcpp/rclcpp.hpp>
 #include <pluginlib/class_loader.hpp>
 #include <tf2_ros/transform_broadcaster.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
-/* ros messages */
+/* ROS messages */
 #include <aerial_robot_msgs/msg/states.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
-//#include <geographic_msgs/msg/geo_point.hpp>
+//#Include <geographic_msgs/msg/geo_point.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
 #include <std_msgs/msg/u_int8.hpp>
 
-using StatusVector = std::array<int, 3>; // x, y, z
-using StatusMatrix = std::array<StatusVector, 3>; // egomotion, experiment, ground truth
+using StatusVector = std::array<int, 3>;           // X, y, z
+using StatusMatrix = std::array<StatusVector, 3>;  // Egomotion, experiment, ground truth
 using FuserPtr = std::shared_ptr<kf_plugin::KalmanFilter>;
 using FuserList = std::vector<std::pair<std::string, FuserPtr>>;
 
-namespace State {
-  enum {
-      X, Y, Z
-  };
+namespace State
+{
+enum
+{
+  X,
+  Y,
+  Z
+};
 };
 
-namespace Sensor {
-  enum {
-    UNHEALTH_LEVEL1 = 1, // do nothing
-    UNHEALTH_LEVEL2, // change estimation mode
-    UNHEALTH_LEVEL3, // force landing
-  };
+namespace Sensor
+{
+enum
+{
+  UNHEALTH_LEVEL1 = 1,  // Do nothing
+  UNHEALTH_LEVEL2,      // Change estimation mode
+  UNHEALTH_LEVEL3,      // Force landing
+};
 };
 
-/* pre-definition */
-namespace sensor_plugin {
-  class  SensorBase;
+/* Pre-definition */
+namespace sensor_plugin
+{
+class SensorBase;
 };
 
 
-namespace aerial_robot_estimation {
-  //mode
-  static constexpr int NONE = -1;
-  static constexpr int EGOMOTION_ESTIMATE = 0;
-  static constexpr int EXPERIMENT_ESTIMATE = 1;
-  static constexpr int GROUND_TRUTH = 2;
+namespace aerial_robot_estimation
+{
+// Mode
+static constexpr int NONE = -1;
+static constexpr int EGOMOTION_ESTIMATE = 0;
+static constexpr int EXPERIMENT_ESTIMATE = 1;
+static constexpr int GROUND_TRUTH = 2;
 
-  static constexpr float G = 9.797;
+static constexpr float G = 9.797;
 
-  class StateEstimator: public std::enable_shared_from_this<StateEstimator> {
+class StateEstimator : public std::enable_shared_from_this<StateEstimator>
+{
+public:
+  StateEstimator();
+  virtual ~StateEstimator() = default;
 
-  public:
-    StateEstimator();
-    virtual ~StateEstimator() = default;
+  void initialize(rclcpp::Node::SharedPtr node, std::shared_ptr<aerial_robot_model::RobotModel> robot_model);
 
-    void initialize(rclcpp::Node::SharedPtr node, std::shared_ptr<aerial_robot_model::RobotModel> robot_model);
+  int getBasePosStateStatus(uint8_t axis, uint8_t estimate_mode);
+  int getCogPosStateStatus(uint8_t axis, uint8_t estimate_mode);
+  int getBaseRotStateStatus(uint8_t estimate_mode);
+  int getCogRotStateStatus(uint8_t estimate_mode);
+  void setBasePosStateStatus(uint8_t axis, uint8_t estimate_mode, bool status);
+  void setCogPosStateStatus(uint8_t axis, uint8_t estimate_mode, bool status);
+  void setBaseRotStateStatus(uint8_t estimate_mode, bool status);
+  void setCogRotStateStatus(uint8_t estimate_mode, bool status);
 
-    int getBasePosStateStatus(uint8_t axis, uint8_t estimate_mode);
-    int getCogPosStateStatus(uint8_t axis, uint8_t estimate_mode);
-    int getBaseRotStateStatus(uint8_t estimate_mode);
-    int getCogRotStateStatus(uint8_t estimate_mode);
-    void setBasePosStateStatus(uint8_t axis, uint8_t estimate_mode, bool status);
-    void setCogPosStateStatus(uint8_t axis, uint8_t estimate_mode, bool status);
-    void setBaseRotStateStatus(uint8_t estimate_mode, bool status);
-    void setCogRotStateStatus(uint8_t estimate_mode, bool status);
+  const KDL::Frame getBasePose(int estimate_mode);
+  void setBasePose(int estimate_mode, KDL::Frame pose);
+  const KDL::Twist getBaseTwist(int estimate_mode);
+  void setBaseTwist(int estimate_mode, KDL::Twist twist);
+  const KDL::Vector getBasePos(int estimate_mode);
+  void setBasePos(int estimate_mode, KDL::Vector pos);
+  void setBasePosX(int estimate_mode, double pos);
+  void setBasePosY(int estimate_mode, double pos);
+  void setBasePosZ(int estimate_mode, double pos);
+  const KDL::Vector getBaseVel(int estimate_mode);
+  void setBaseVel(int estimate_mode, KDL::Vector vel);
+  void setBaseVelX(int estimate_mode, double vel);
+  void setBaseVelY(int estimate_mode, double vel);
+  void setBaseVelZ(int estimate_mode, double vel);
+  const KDL::Vector getBaseAcc(int estimate_mode);
+  void setBaseAcc(int estimate_mode, KDL::Vector acc);
 
-    const KDL::Frame getBasePose(int estimate_mode);
-    void setBasePose(int estimate_mode, KDL::Frame pose);
-    const KDL::Twist getBaseTwist(int estimate_mode);
-    void setBaseTwist(int estimate_mode, KDL::Twist twist);
-    const KDL::Vector getBasePos(int estimate_mode);
-    void setBasePos(int estimate_mode, KDL::Vector pos);
-    void setBasePosX(int estimate_mode, double pos);
-    void setBasePosY(int estimate_mode, double pos);
-    void setBasePosZ(int estimate_mode, double pos);
-    const KDL::Vector getBaseVel(int estimate_mode);
-    void setBaseVel(int estimate_mode, KDL::Vector vel);
-    void setBaseVelX(int estimate_mode, double vel);
-    void setBaseVelY(int estimate_mode, double vel);
-    void setBaseVelZ(int estimate_mode, double vel);
-    const KDL::Vector getBaseAcc(int estimate_mode);
-    void setBaseAcc(int estimate_mode, KDL::Vector acc);
+  const KDL::Rotation getBaseOrientation(int estimate_mode);
+  void setBaseOrientation(int estimate_mode, KDL::Rotation rot);
+  const KDL::Vector getBaseEuler(int estimate_mode);
+  const KDL::Vector getBaseAngularVel(int estimate_mode);
+  void setBaseAngularVel(int estimate_mode, KDL::Vector omega);
 
-    const KDL::Rotation getBaseOrientation(int estimate_mode);
-    void setBaseOrientation(int estimate_mode, KDL::Rotation rot);
-    const KDL::Vector getBaseEuler(int estimate_mode);
-    const KDL::Vector getBaseAngularVel(int estimate_mode);
-    void setBaseAngularVel(int estimate_mode, KDL::Vector omega);
+  const KDL::Frame getCogPose(int estimate_mode);
+  void setCogPose(int estimate_mode, KDL::Frame pose);
+  const KDL::Twist getCogTwist(int estimate_mode);
+  void setCogTwist(int estimate_mode, KDL::Twist twist);
+  const KDL::Vector getCogPos(int estimate_mode);
+  void setCogPos(int estimate_mode, KDL::Vector pos);
+  const KDL::Vector getCogVel(int estimate_mode);
+  void setCogVel(int estimate_mode, KDL::Vector vel);
+  const KDL::Vector getCogAcc(int estimate_mode);
+  void setCogAcc(int estimate_mode, KDL::Vector acc);
+  const KDL::Rotation getCogOrientation(int estimate_mode);
+  void setCogOrientation(int estimate_mode, KDL::Rotation rot);
+  const KDL::Vector getCogEuler(int estimate_mode);
+  const KDL::Vector getCogAngularVel(int estimate_mode);
+  void setCogAngularVel(int estimate_mode, KDL::Vector omega);
 
-    const KDL::Frame getCogPose(int estimate_mode);
-    void setCogPose(int estimate_mode, KDL::Frame pose);
-    const KDL::Twist getCogTwist(int estimate_mode);
-    void setCogTwist(int estimate_mode, KDL::Twist twist);
-    const KDL::Vector getCogPos(int estimate_mode);
-    void setCogPos(int estimate_mode, KDL::Vector pos);
-    const KDL::Vector getCogVel(int estimate_mode);
-    void setCogVel(int estimate_mode, KDL::Vector vel);
-    const KDL::Vector getCogAcc(int estimate_mode);
-    void setCogAcc(int estimate_mode, KDL::Vector acc);
-    const KDL::Rotation getCogOrientation(int estimate_mode);
-    void setCogOrientation(int estimate_mode, KDL::Rotation rot);
-    const KDL::Vector getCogEuler(int estimate_mode);
-    const KDL::Vector getCogAngularVel(int estimate_mode);
-    void setCogAngularVel(int estimate_mode, KDL::Vector omega);
-
-    void setBaseOrientationWxB(int estimate_mode, KDL::Vector v);
-    void setBaseOrientationWzB(int estimate_mode, KDL::Vector v);
-    void setCogOrientationWxB(int estimate_mode, KDL::Vector v);
-    void setCogOrientationWzB(int estimate_mode, KDL::Vector v);
-
-
-    inline void setBaseQueueSize(const int& qu_size) {qu_size_ = qu_size;}
-    void updateBaseQueue(const double timestamp, const KDL::Rotation r_ee, const KDL::Rotation r_ex, const KDL::Vector omega);
-    bool findBaseRotOmega(const double timestamp, const int mode, KDL::Rotation& r, KDL::Vector& omega, bool verbose = true);
-
-    const double getImuLatestTimeStamp();
-
-    inline void setSensorFusionFlag(bool flag){sensor_fusion_flag_ = flag;  }
-    inline bool getSensorFusionFlag(){return sensor_fusion_flag_; }
-
-    //start flying flag (~takeoff)
-    virtual bool getFlyingFlag() {  return  flying_flag_;}
-    virtual void setFlyingFlag(bool flag){  flying_flag_ = flag;}
-    /* when takeoff, should use the undescend mode be true */
-    inline void setUnDescendMode(bool flag){un_descend_flag_ = flag;  }
-    inline bool getUnDescendMode(){return un_descend_flag_; }
-    /* att control mode is for user to manually control x and y motion by attitude control */
-    inline void setForceAttControlFlag (bool flag) {force_att_control_flag_ = flag; }
-    inline bool getForceAttControlFlag () {return force_att_control_flag_;}
-    /* latitude & longitude value for GPS based navigation */
-    // inline void setCurrGpsPoint(const geographic_msgs::GeoPoint point) {curr_wgs84_poiont_ = point;}
-    // inline const geographic_msgs::GeoPoint& getCurrGpsPoint() const {return curr_wgs84_poiont_;}
-    inline const bool hasGroundTruthOdom() const {return has_groundtruth_odom_; }
-    inline void receiveGroundTruthOdom(bool flag) {has_groundtruth_odom_ = flag; }
-    inline const bool hasRefinedYawEstimate(int i) const {return has_refined_yaw_estimate_.at(i); }
-    inline void SetRefinedYawEstimate(int i, bool flag) {has_refined_yaw_estimate_.at(i) = flag; }
-
-    const FuserList& getFuserList(int mode);
-
-    inline int getEstimateMode() {return estimate_mode_;}
-    inline void setEstimateMode(int estimate_mode) {estimate_mode_ = estimate_mode;}
-
-    /* set unhealth level */
-    void setUnhealthLevel(uint8_t unhealth_level);
-
-    inline uint8_t getUnhealthLevel() { return unhealth_level_; }
-    std::string getTFPrefix() {return tf_prefix_;}
-
-    const vector<std::shared_ptr<sensor_plugin::SensorBase> >& getImuHandlers() const { return imu_handlers_;}
-    const vector<std::shared_ptr<sensor_plugin::SensorBase> >& getAltHandlers() const { return alt_handlers_;}
-    const vector<std::shared_ptr<sensor_plugin::SensorBase> >& getVoHandlers() const { return vo_handlers_;}
-    const vector<std::shared_ptr<sensor_plugin::SensorBase> >& getGpsHandlers() const { return gps_handlers_;}
-
-    const std::shared_ptr<sensor_plugin::SensorBase> getImuHandler(int i) const { return imu_handlers_.at(i);}
-    const std::shared_ptr<sensor_plugin::SensorBase> getAltHandlers(int i) const { return alt_handlers_.at(i);}
-    const std::shared_ptr<sensor_plugin::SensorBase> getVoHandlers(int i) const { return vo_handlers_.at(i);}
-    const std::shared_ptr<sensor_plugin::SensorBase> getGpsHandlers(int i) const { return gps_handlers_.at(i);}
-
-  protected:
-
-    /* node handle */
-    rclcpp::Node::SharedPtr node_;
-
-    /* publisher */
-    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr baselink_odom_pub_, cog_odom_pub_;
-
-    /* timer */
-    rclcpp::TimerBase::SharedPtr state_process_timer_;
-
-    /* tf broadcaster */
-    std::shared_ptr<tf2_ros::TransformBroadcaster> br_;
+  void setBaseOrientationWxB(int estimate_mode, KDL::Vector v);
+  void setBaseOrientationWzB(int estimate_mode, KDL::Vector v);
+  void setCogOrientationWxB(int estimate_mode, KDL::Vector v);
+  void setCogOrientationWzB(int estimate_mode, KDL::Vector v);
 
 
-    /* sensor handlers */
-    std::shared_ptr<pluginlib::ClassLoader<sensor_plugin::SensorBase>> sensor_loader_ptr_;
-    vector<std::shared_ptr<sensor_plugin::SensorBase> > sensors_;
-    vector<std::shared_ptr<sensor_plugin::SensorBase> > imu_handlers_;
-    vector<std::shared_ptr<sensor_plugin::SensorBase> > alt_handlers_;
-    vector<std::shared_ptr<sensor_plugin::SensorBase> > vo_handlers_;
-    vector<std::shared_ptr<sensor_plugin::SensorBase> > gps_handlers_;
+  inline void setBaseQueueSize(const int &qu_size) { qu_size_ = qu_size; }
+  void updateBaseQueue(const double timestamp, const KDL::Rotation r_ee, const KDL::Rotation r_ex,
+                       const KDL::Vector omega);
+  bool findBaseRotOmega(const double timestamp, const int mode, KDL::Rotation &r, KDL::Vector &omega,
+                        bool verbose = true);
 
-    /* mutex */
-    std::mutex state_mutex_;
-    std::mutex queue_mutex_;
-    /* ros param */
-    int estimate_mode_; /* main estimte mode */
+  const double getImuLatestTimeStamp();
 
-    /* robot model (kinematics)  */
-    std::shared_ptr<aerial_robot_model::RobotModel> robot_model_;
-    std::string tf_prefix_;
+  inline void setSensorFusionFlag(bool flag) { sensor_fusion_flag_ = flag; }
+  inline bool getSensorFusionFlag() { return sensor_fusion_flag_; }
 
-    /* states */
-    StatusMatrix base_pos_status_matrix_, cog_pos_status_matrix_;
-    std::array<int, 3> base_rot_status_, cog_rot_status_;
-    std::array<KDL::Frame, 3> base_pose_, cog_pose_;
-    std::array<KDL::Twist, 3> base_twist_, cog_twist_;
-    std::array<KDL::Vector, 3> base_acc_, cog_acc_;
+  // Start flying flag (~takeoff)
+  virtual bool getFlyingFlag() { return flying_flag_; }
+  virtual void setFlyingFlag(bool flag) { flying_flag_ = flag; }
+  /* When takeoff, should use the undescend mode be true */
+  inline void setUnDescendMode(bool flag) { un_descend_flag_ = flag; }
+  inline bool getUnDescendMode() { return un_descend_flag_; }
+  /* Att control mode is for user to manually control x and y motion by attitude control */
+  inline void setForceAttControlFlag(bool flag) { force_att_control_flag_ = flag; }
+  inline bool getForceAttControlFlag() { return force_att_control_flag_; }
+  /* Latitude & longitude value for GPS based navigation */
+  // Inline void setCurrGpsPoint(const geographic_msgs::GeoPoint point) {curr_wgs84_poiont_ = point;}
+  // Inline const geographic_msgs::GeoPoint& getCurrGpsPoint() const {return curr_wgs84_poiont_;}
+  inline const bool hasGroundTruthOdom() const { return has_groundtruth_odom_; }
+  inline void receiveGroundTruthOdom(bool flag) { has_groundtruth_odom_ = flag; }
+  inline const bool hasRefinedYawEstimate(int i) const { return has_refined_yaw_estimate_.at(i); }
+  inline void SetRefinedYawEstimate(int i, bool flag) { has_refined_yaw_estimate_.at(i) = flag; }
 
-    bool has_groundtruth_odom_; // whether receive entire groundthtruth odometry (e.g., for simulation mode)
+  const FuserList &getFuserList(int mode);
 
-    std::map<int, bool> has_refined_yaw_estimate_; // whether receive refined yaw estimation data (e.g., vio) for each estimate mode
+  inline int getEstimateMode() { return estimate_mode_; }
+  inline void setEstimateMode(int estimate_mode) { estimate_mode_ = estimate_mode; }
 
-    /* for calculate the sensor to baselink with the consideration of time delay */
-    int qu_size_;
-    deque<double> timestamp_qu_;
-    deque<KDL::Rotation> base_rot_ee_qu_, base_rot_ex_qu_;
-    deque<KDL::Vector> base_omega_qu_;
+  /* Set unhealth level */
+  void setUnhealthLevel(uint8_t unhealth_level);
 
-    /* sensor fusion */
-    std::shared_ptr<pluginlib::ClassLoader<kf_plugin::KalmanFilter>> fusion_loader_ptr_;
-    bool sensor_fusion_flag_;
-    std::array<FuserList, 2> fuser_maps_; //0: egomotion; 1: experiment
+  inline uint8_t getUnhealthLevel() { return unhealth_level_; }
+  std::string getTFPrefix() { return tf_prefix_; }
 
-    /* sensor (un)health level */
-    uint8_t unhealth_level_;
+  const vector<std::shared_ptr<sensor_plugin::SensorBase>> &getImuHandlers() const { return imu_handlers_; }
+  const vector<std::shared_ptr<sensor_plugin::SensorBase>> &getAltHandlers() const { return alt_handlers_; }
+  const vector<std::shared_ptr<sensor_plugin::SensorBase>> &getVoHandlers() const { return vo_handlers_; }
+  const vector<std::shared_ptr<sensor_plugin::SensorBase>> &getGpsHandlers() const { return gps_handlers_; }
 
-    /* height related var */
-    bool flying_flag_;
-    bool un_descend_flag_;
-    bool force_att_control_flag_;
+  const std::shared_ptr<sensor_plugin::SensorBase> getImuHandler(int i) const { return imu_handlers_.at(i); }
+  const std::shared_ptr<sensor_plugin::SensorBase> getAltHandlers(int i) const { return alt_handlers_.at(i); }
+  const std::shared_ptr<sensor_plugin::SensorBase> getVoHandlers(int i) const { return vo_handlers_.at(i); }
+  const std::shared_ptr<sensor_plugin::SensorBase> getGpsHandlers(int i) const { return gps_handlers_.at(i); }
 
-    /* latitude & longitude point */
-    //geographic_msgs::GeoPoint curr_wgs84_poiont_;
+protected:
+  /* Node handle */
+  rclcpp::Node::SharedPtr node_;
 
-    /* time */
-    rclcpp::Time prev_pub_stamp_;
+  /* Publisher */
+  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr baselink_odom_pub_, cog_odom_pub_;
 
-    void process();
-    void sensorHealthCheck();
-    void publish();
-    void odomPublish(rclcpp::Time stamp);
-    void tfBroadcast(rclcpp::Time stamp);
-    void load();
-  };
+  /* Timer */
+  rclcpp::TimerBase::SharedPtr state_process_timer_;
+
+  /* Tf broadcaster */
+  std::shared_ptr<tf2_ros::TransformBroadcaster> br_;
+
+
+  /* Sensor handlers */
+  std::shared_ptr<pluginlib::ClassLoader<sensor_plugin::SensorBase>> sensor_loader_ptr_;
+  vector<std::shared_ptr<sensor_plugin::SensorBase>> sensors_;
+  vector<std::shared_ptr<sensor_plugin::SensorBase>> imu_handlers_;
+  vector<std::shared_ptr<sensor_plugin::SensorBase>> alt_handlers_;
+  vector<std::shared_ptr<sensor_plugin::SensorBase>> vo_handlers_;
+  vector<std::shared_ptr<sensor_plugin::SensorBase>> gps_handlers_;
+
+  /* Mutex */
+  std::mutex state_mutex_;
+  std::mutex queue_mutex_;
+  /* ROS param */
+  int estimate_mode_; /* Main estimte mode */
+
+  /* Robot model (kinematics)  */
+  std::shared_ptr<aerial_robot_model::RobotModel> robot_model_;
+  std::string tf_prefix_;
+
+  /* States */
+  StatusMatrix base_pos_status_matrix_, cog_pos_status_matrix_;
+  std::array<int, 3> base_rot_status_, cog_rot_status_;
+  std::array<KDL::Frame, 3> base_pose_, cog_pose_;
+  std::array<KDL::Twist, 3> base_twist_, cog_twist_;
+  std::array<KDL::Vector, 3> base_acc_, cog_acc_;
+
+  bool has_groundtruth_odom_;  // Whether receive entire groundthtruth odometry (e.g., for simulation mode)
+
+  std::map<int, bool> has_refined_yaw_estimate_;  // Whether receive refined yaw estimation data (e.g., vio) for each
+                                                  // Estimate mode
+
+  /* For calculate the sensor to baselink with the consideration of time delay */
+  int qu_size_;
+  deque<double> timestamp_qu_;
+  deque<KDL::Rotation> base_rot_ee_qu_, base_rot_ex_qu_;
+  deque<KDL::Vector> base_omega_qu_;
+
+  /* Sensor fusion */
+  std::shared_ptr<pluginlib::ClassLoader<kf_plugin::KalmanFilter>> fusion_loader_ptr_;
+  bool sensor_fusion_flag_;
+  std::array<FuserList, 2> fuser_maps_;  // 0: Egomotion; 1: experiment
+
+  /* Sensor (un)health level */
+  uint8_t unhealth_level_;
+
+  /* Height related var */
+  bool flying_flag_;
+  bool un_descend_flag_;
+  bool force_att_control_flag_;
+
+  /* Latitude & longitude point */
+  // geographic_msgs::GeoPoint curr_wgs84_poiont_;
+
+  /* Time */
+  rclcpp::Time prev_pub_stamp_;
+
+  void process();
+  void sensorHealthCheck();
+  void publish();
+  void odomPublish(rclcpp::Time stamp);
+  void tfBroadcast(rclcpp::Time stamp);
+  void load();
 };
+};  // Namespace aerial_robot_estimation

--- a/aerial_robot_estimation/src/state_estimation.cpp
+++ b/aerial_robot_estimation/src/state_estimation.cpp
@@ -1,4 +1,4 @@
-// -*- mode: c++ -*-
+// -*- Mode: c++ -*-
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
@@ -37,8 +37,7 @@
 #include <aerial_robot_estimation/state_estimation.h>
 
 using namespace aerial_robot_estimation;
-static const rclcpp::Logger LOGGER
-= rclcpp::get_logger("state_estimation");
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("state_estimation");
 
 StateEstimator::StateEstimator()
   : sensor_fusion_flag_(false),
@@ -49,14 +48,18 @@ StateEstimator::StateEstimator()
     un_descend_flag_(false),
     force_att_control_flag_(false),
     has_groundtruth_odom_(false),
-    imu_handlers_(0), alt_handlers_(0), vo_handlers_(0), gps_handlers_(0)
+    imu_handlers_(0),
+    alt_handlers_(0),
+    vo_handlers_(0),
+    gps_handlers_(0)
 {
   has_refined_yaw_estimate_[EGOMOTION_ESTIMATE] = false;
   has_refined_yaw_estimate_[EXPERIMENT_ESTIMATE] = false;
 
-  for(int i = 0; i < 3; i++) {
-
-    for(int j = 0; j < 3; j++) {
+  for (int i = 0; i < 3; i++)
+  {
+    for (int j = 0; j < 3; j++)
+    {
       base_pos_status_matrix_.at(i).at(j) = 0;
       cog_pos_status_matrix_.at(i).at(j) = 0;
     }
@@ -68,16 +71,17 @@ StateEstimator::StateEstimator()
   }
 }
 
-void StateEstimator::initialize(rclcpp::Node::SharedPtr node, std::shared_ptr<aerial_robot_model::RobotModel> robot_model) {
+void StateEstimator::initialize(rclcpp::Node::SharedPtr node,
+                                std::shared_ptr<aerial_robot_model::RobotModel> robot_model)
+{
   node_ = node;
   robot_model_ = robot_model;
 
   load();
 
-  baselink_odom_pub_ = node_->create_publisher<nav_msgs::msg::Odometry>
-    ("uav/baselink/odom", rclcpp::SystemDefaultsQoS());
-  cog_odom_pub_ = node_->create_publisher<nav_msgs::msg::Odometry>
-    ("uav/cog/odom", rclcpp::SystemDefaultsQoS());
+  baselink_odom_pub_ = node_->create_publisher<nav_msgs::msg::Odometry>("uav/baselink/odom",
+                                                                        rclcpp::SystemDefaultsQoS());
+  cog_odom_pub_ = node_->create_publisher<nav_msgs::msg::Odometry>("uav/cog/odom", rclcpp::SystemDefaultsQoS());
 
   node_->get_parameter_or("tf_prefix", tf_prefix_, std::string(""));
   br_ = std::make_shared<tf2_ros::TransformBroadcaster>(node_);
@@ -86,130 +90,149 @@ void StateEstimator::initialize(rclcpp::Node::SharedPtr node, std::shared_ptr<ae
   node_->get_parameter_or("state_pub_rate", rate, 100.0);
   auto period = std::chrono::duration<double>(1.0 / rate);
   state_process_timer_ = rclcpp::create_timer(node_, node_->get_clock(), period,
-                                          std::bind(&StateEstimator::process, this));
+                                              std::bind(&StateEstimator::process, this));
 }
 
-void StateEstimator::load() {
-  auto pattern_match = [](std::string &pl, std::string &pl_candidate) {
+void StateEstimator::load()
+{
+  auto pattern_match = [](std::string &pl, std::string &pl_candidate)
+  {
     int cmp = fnmatch(pl.c_str(), pl_candidate.c_str(), FNM_CASEFOLD);
-    if (cmp == 0)
-      return true;
+    if (cmp == 0) return true;
 
-    if (cmp != FNM_NOMATCH) {
-      RCLCPP_ERROR(LOGGER,
-                "Plugin list check error! fnmatch('%s', '%s', FNM_CASEFOLD) -> %d",
-                pl.c_str(), pl_candidate.c_str(), cmp);
+    if (cmp != FNM_NOMATCH)
+    {
+      RCLCPP_ERROR(LOGGER, "Plugin list check error! fnmatch('%s', '%s', FNM_CASEFOLD) -> %d", pl.c_str(),
+                   pl_candidate.c_str(), cmp);
     }
 
     return false;
   };
 
-  node_->get_parameter_or("estimation.mode", estimate_mode_, 0); //EGOMOTION_ESTIMATE: 0
-  if (estimate_mode_ > GROUND_TRUTH) {
-      RCLCPP_ERROR(LOGGER,"the estimate mode is not correct: %d. \
-                   It should be [0, 1, 2].",
-                  estimate_mode_);
-      return;
+  node_->get_parameter_or("estimation.mode", estimate_mode_, 0);  // EGOMOTION_ESTIMATE: 0
+  if (estimate_mode_ > GROUND_TRUTH)
+  {
+    RCLCPP_ERROR(LOGGER, "The estimate mode is not correct: %d. It should be [0, 1, 2].", estimate_mode_);
+    return;
   }
 
-  std::string estimate_mode_str
-    = (estimate_mode_ == EGOMOTION_ESTIMATE)? std::string("EGOMOTION_ESTIMATE"):
-    ((estimate_mode_ == EXPERIMENT_ESTIMATE)?
-     std::string("EXPERIMENT_ESTIMATE"): std::string("GROUND_TRUTH"));
-  RCLCPP_INFO_STREAM(LOGGER, std::string("\033[32m estimate mode: ") <<
-                     estimate_mode_str << std::string("\033[0m"));
+  std::string estimate_mode_str;
+  if (estimate_mode_ == EGOMOTION_ESTIMATE)
+  {
+    estimate_mode_str = "EGOMOTION_ESTIMATE";
+  }
+  else if (estimate_mode_ == EXPERIMENT_ESTIMATE)
+  {
+    estimate_mode_str = "EXPERIMENT_ESTIMATE";
+  }
+  else if (estimate_mode_ == GROUND_TRUTH)
+  {
+    estimate_mode_str = "GROUND_TRUTH";
+  }
+  RCLCPP_INFO_STREAM(LOGGER, std::string("\033[32m estimate mode: ") << estimate_mode_str << std::string("\033[0m"));
 
-  /* kalman filter egomotion plugin initialization for 0: egomotion, 1: experiment */
-  fusion_loader_ptr_ = std::make_shared<pluginlib::ClassLoader<kf_plugin::KalmanFilter>>("kalman_filter", "kf_plugin::KalmanFilter");
+  /* Kalman filter egomotion plugin initialization for 0: egomotion, 1: experiment */
+  fusion_loader_ptr_ = std::make_shared<pluginlib::ClassLoader<kf_plugin::KalmanFilter>>("kalman_filter",
+                                                                                         "kf_plugin::KalmanFilter");
 
-  string fuse_prefix = "estimation.fusion.";
-  for (int i = 0; i < 2; i++) {
-    /* kalman filter egomotion plugin list */
-    string mode_prefix;
-    if(i == EGOMOTION_ESTIMATE) mode_prefix = string("egomotion");
-    else if(i == EXPERIMENT_ESTIMATE) mode_prefix = string("experiment");
+  std::string fuse_prefix = "estimation.fusion.";
+  for (int i = 0; i < 2; i++)
+  {
+    /* Kalman filter egomotion plugin list */
+    std::string mode_prefix;
+    if (i == EGOMOTION_ESTIMATE)
+      mode_prefix = "egomotion";
+    else if (i == EXPERIMENT_ESTIMATE)
+      mode_prefix = "experiment";
 
     std::vector<std::string> fuser_list;
-    if(!node_->get_parameter<std::vector<std::string>>
-       (fuse_prefix + mode_prefix + "_list", fuser_list)) {
-      RCLCPP_ERROR_STREAM(LOGGER,
-                          fuse_prefix << mode_prefix << "_list" << " is not set");
+    if (!node_->get_parameter<std::vector<std::string>>(fuse_prefix + mode_prefix + "_list", fuser_list))
+    {
+      RCLCPP_ERROR_STREAM(LOGGER, fuse_prefix << mode_prefix << "_list is not set");
       return;
     }
 
     int cnt = 0;
-    for (auto &fuser_name : fuser_list) {
-      for (auto &name : fusion_loader_ptr_->getDeclaredClasses()) {
-        if(!pattern_match(fuser_name, name)) continue;
+    for (auto &fuser_name : fuser_list)
+    {
+      for (auto &name : fusion_loader_ptr_->getDeclaredClasses())
+      {
+        if (!pattern_match(fuser_name, name)) continue;
 
         std::stringstream fuser_no;
         fuser_no << ++cnt;
 
         int fuser_id;
-        std::string fuser_id_param
-          = fuse_prefix + mode_prefix + "_id" + fuser_no.str();
-        if (!node_->get_parameter<int>(fuser_id_param, fuser_id)) {
-          RCLCPP_ERROR(LOGGER, "%s, no param in fuser %s id",
-                       mode_prefix.c_str(), fuser_no.str().c_str());
+        std::string fuser_id_param = fuse_prefix + mode_prefix + "_id" + fuser_no.str();
+        if (!node_->get_parameter<int>(fuser_id_param, fuser_id))
+        {
+          RCLCPP_ERROR(LOGGER, "%s, no param in fuser %s id", mode_prefix.c_str(), fuser_no.str().c_str());
           continue;
         }
 
         std::string fuser_label;
-        std::string fuser_name_param
-          = fuse_prefix + mode_prefix + "_label" + fuser_no.str();
-        if (!node_->get_parameter<std::string>(fuser_name_param, fuser_label)) {
-          RCLCPP_ERROR(LOGGER, "%s, no param in fuser %s name",
-                       mode_prefix.c_str(), fuser_no.str().c_str());
+        std::string fuser_name_param = fuse_prefix + mode_prefix + "_label" + fuser_no.str();
+        if (!node_->get_parameter<std::string>(fuser_name_param, fuser_label))
+        {
+          RCLCPP_ERROR(LOGGER, "%s, no param in fuser %s name", mode_prefix.c_str(), fuser_no.str().c_str());
           continue;
         }
 
-        try {
-          std::shared_ptr<kf_plugin::KalmanFilter> plugin_ptr
-            = fusion_loader_ptr_->createSharedInstance(name);
+        try
+        {
+          std::shared_ptr<kf_plugin::KalmanFilter> plugin_ptr = fusion_loader_ptr_->createSharedInstance(name);
           plugin_ptr->initialize(fuser_label, fuser_id);
           fuser_maps_.at(i).push_back(std::make_pair(name, plugin_ptr));
-        } catch (const pluginlib::PluginlibException& ex) {
-          RCLCPP_ERROR(LOGGER,
-                       "Failed to load kf plugin '%s': %s",
-                       name.c_str(), ex.what());
+        }
+        catch (const pluginlib::PluginlibException &ex)
+        {
+          RCLCPP_ERROR(LOGGER, "Failed to load kf plugin '%s': %s", name.c_str(), ex.what());
         }
       }
     }
   }
 
-  sensor_loader_ptr_ = std::make_shared<pluginlib::ClassLoader<sensor_plugin::SensorBase>>("aerial_robot_estimation", "sensor_plugin::SensorBase");
+  sensor_loader_ptr_ = std::make_shared<pluginlib::ClassLoader<sensor_plugin::SensorBase>>("aerial_robot_estimation",
+                                                                                           "sensor_plugin::SensorBase");
 
   std::vector<std::string> sensor_list{};
-  if(!node_->get_parameter<std::vector<std::string>>(fuse_prefix + "sensor_list", sensor_list)) {
-    RCLCPP_ERROR_STREAM(LOGGER, fuse_prefix + "sensor_list" << " is not set");
+  if (!node_->get_parameter<std::vector<std::string>>(fuse_prefix + "sensor_list", sensor_list))
+  {
+    RCLCPP_ERROR_STREAM(LOGGER, fuse_prefix << "sensor_list is not set");
     return;
   }
 
-  vector<int> sensor_index(0);
+  std::vector<int> sensor_index(0);
 
-  for (auto &plugin_name : sensor_list) {
-    for (auto &name : sensor_loader_ptr_->getDeclaredClasses()) {
-      if(!pattern_match(plugin_name, name)) continue;
+  for (auto &plugin_name : sensor_list)
+  {
+    for (auto &name : sensor_loader_ptr_->getDeclaredClasses())
+    {
+      if (!pattern_match(plugin_name, name)) continue;
 
       sensors_.push_back(sensor_loader_ptr_->createSharedInstance(name));
       sensor_index.push_back(1);
 
-      if(name.find("imu") != std::string::npos) {
+      if (name.find("imu") != std::string::npos)
+      {
         imu_handlers_.push_back(sensors_.back());
         sensor_index.back() = imu_handlers_.size();
       }
 
-      if(name.find("gps") != std::string::npos) {
+      if (name.find("gps") != std::string::npos)
+      {
         gps_handlers_.push_back(sensors_.back());
         sensor_index.back() = gps_handlers_.size();
       }
 
-      if(name.find("alt") != std::string::npos) {
+      if (name.find("alt") != std::string::npos)
+      {
         alt_handlers_.push_back(sensors_.back());
         sensor_index.back() = alt_handlers_.size();
       }
 
-      if(name.find("vo") != std::string::npos) {
+      if (name.find("vo") != std::string::npos)
+      {
         vo_handlers_.push_back(sensors_.back());
         sensor_index.back() = vo_handlers_.size();
       }
@@ -221,287 +244,350 @@ void StateEstimator::load() {
   }
 }
 
-int StateEstimator::getBasePosStateStatus(uint8_t axis, uint8_t estimate_mode) {
+int StateEstimator::getBasePosStateStatus(uint8_t axis, uint8_t estimate_mode)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
 
   return base_pos_status_matrix_.at(estimate_mode).at(axis);
 }
 
-void StateEstimator::setBasePosStateStatus(uint8_t axis, uint8_t estimate_mode, bool status) {
+void StateEstimator::setBasePosStateStatus(uint8_t axis, uint8_t estimate_mode, bool status)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
 
-  int& curr_status = base_pos_status_matrix_.at(estimate_mode).at(axis);
+  int &curr_status = base_pos_status_matrix_.at(estimate_mode).at(axis);
 
-  if(status) {
+  if (status)
+  {
     curr_status++;
-  } else {
-    if(curr_status > 0) {
-      curr_status --;
-    } else {
-      RCLCPP_WARN(LOGGER,
-                  "wrong pos status update for axis: %d, estimate mode: %d",
-                  axis, estimate_mode);
+  }
+  else
+  {
+    if (curr_status > 0)
+    {
+      curr_status--;
+    }
+    else
+    {
+      RCLCPP_WARN(LOGGER, "wrong pos status update for axis: %d, estimate mode: %d", axis, estimate_mode);
     }
   }
 }
 
-int StateEstimator::getBaseRotStateStatus(uint8_t estimate_mode) {
+int StateEstimator::getBaseRotStateStatus(uint8_t estimate_mode)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
 
   return base_rot_status_.at(estimate_mode);
 }
 
-void StateEstimator::setBaseRotStateStatus(uint8_t estimate_mode, bool status) {
+void StateEstimator::setBaseRotStateStatus(uint8_t estimate_mode, bool status)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
 
-  int& curr_status = base_rot_status_.at(estimate_mode);
+  int &curr_status = base_rot_status_.at(estimate_mode);
 
-  if(status) {
+  if (status)
+  {
     curr_status++;
-  } else {
-    if(curr_status > 0) {
-      curr_status --;
-    } else {
-      RCLCPP_WARN(LOGGER,
-                  "wrong rot status update for estimate mode: %d", estimate_mode);
+  }
+  else
+  {
+    if (curr_status > 0)
+    {
+      curr_status--;
+    }
+    else
+    {
+      RCLCPP_WARN(LOGGER, "wrong rot status update for estimate mode: %d", estimate_mode);
     }
   }
 }
 
-int StateEstimator::getCogPosStateStatus(uint8_t axis, uint8_t estimate_mode) {
+int StateEstimator::getCogPosStateStatus(uint8_t axis, uint8_t estimate_mode)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
 
   return cog_pos_status_matrix_.at(estimate_mode).at(axis);
 }
 
-void StateEstimator::setCogPosStateStatus(uint8_t axis, uint8_t estimate_mode, bool status) {
+void StateEstimator::setCogPosStateStatus(uint8_t axis, uint8_t estimate_mode, bool status)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
 
-  int& curr_status = cog_pos_status_matrix_.at(estimate_mode).at(axis);
+  int &curr_status = cog_pos_status_matrix_.at(estimate_mode).at(axis);
 
-  if(status) {
+  if (status)
+  {
     curr_status++;
-  } else {
-    if(curr_status > 0) {
-      curr_status --;
-    } else {
-      RCLCPP_WARN(LOGGER,
-                  "wrong pos status update for axis: %d, estimate mode: %d",
-                  axis, estimate_mode);
+  }
+  else
+  {
+    if (curr_status > 0)
+    {
+      curr_status--;
+    }
+    else
+    {
+      RCLCPP_WARN(LOGGER, "wrong pos status update for axis: %d, estimate mode: %d", axis, estimate_mode);
     }
   }
 }
 
-int StateEstimator::getCogRotStateStatus(uint8_t estimate_mode) {
+int StateEstimator::getCogRotStateStatus(uint8_t estimate_mode)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
 
   return cog_rot_status_.at(estimate_mode);
 }
 
-void StateEstimator::setCogRotStateStatus(uint8_t estimate_mode, bool status) {
+void StateEstimator::setCogRotStateStatus(uint8_t estimate_mode, bool status)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
 
-  int& curr_status = cog_rot_status_.at(estimate_mode);
+  int &curr_status = cog_rot_status_.at(estimate_mode);
 
-  if(status) {
+  if (status)
+  {
     curr_status++;
-  } else {
-    if(curr_status > 0) {
-      curr_status --;
-    } else {
-      RCLCPP_WARN(LOGGER,
-                  "wrong rot status update for estimate mode: %d", estimate_mode);
+  }
+  else
+  {
+    if (curr_status > 0)
+    {
+      curr_status--;
+    }
+    else
+    {
+      RCLCPP_WARN(LOGGER, "wrong rot status update for estimate mode: %d", estimate_mode);
     }
   }
 }
 
-const KDL::Frame StateEstimator::getBasePose(int estimate_mode) {
+const KDL::Frame StateEstimator::getBasePose(int estimate_mode)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   return base_pose_.at(estimate_mode);
 }
 
-void StateEstimator::setBasePose(int estimate_mode, KDL::Frame pose) {
+void StateEstimator::setBasePose(int estimate_mode, KDL::Frame pose)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   base_pose_.at(estimate_mode) = pose;
 }
 
-const KDL::Twist StateEstimator::getBaseTwist(int estimate_mode) {
+const KDL::Twist StateEstimator::getBaseTwist(int estimate_mode)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   return base_twist_.at(estimate_mode);
 }
 
-void StateEstimator::setBaseTwist(int estimate_mode, KDL::Twist twist) {
+void StateEstimator::setBaseTwist(int estimate_mode, KDL::Twist twist)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   base_twist_.at(estimate_mode) = twist;
 }
 
-const KDL::Vector StateEstimator::getBasePos(int estimate_mode) {
+const KDL::Vector StateEstimator::getBasePos(int estimate_mode)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   return base_pose_.at(estimate_mode).p;
 }
 
-void StateEstimator::setBasePos(int estimate_mode, KDL::Vector pos) {
+void StateEstimator::setBasePos(int estimate_mode, KDL::Vector pos)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   base_pose_.at(estimate_mode).p = pos;
 }
 
-void StateEstimator::setBasePosX(int estimate_mode, double pos) {
+void StateEstimator::setBasePosX(int estimate_mode, double pos)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   base_pose_.at(estimate_mode).p.x(pos);
 }
 
-void StateEstimator::setBasePosY(int estimate_mode, double pos) {
+void StateEstimator::setBasePosY(int estimate_mode, double pos)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   base_pose_.at(estimate_mode).p.y(pos);
 }
 
-void StateEstimator::setBasePosZ(int estimate_mode, double pos) {
+void StateEstimator::setBasePosZ(int estimate_mode, double pos)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   base_pose_.at(estimate_mode).p.z(pos);
 }
 
-const KDL::Vector StateEstimator::getBaseVel(int estimate_mode) {
+const KDL::Vector StateEstimator::getBaseVel(int estimate_mode)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   return base_twist_.at(estimate_mode).vel;
 }
 
-void StateEstimator::setBaseVel(int estimate_mode, KDL::Vector vel) {
+void StateEstimator::setBaseVel(int estimate_mode, KDL::Vector vel)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   base_twist_.at(estimate_mode).vel = vel;
 }
 
-void StateEstimator::setBaseVelX(int estimate_mode, double vel) {
+void StateEstimator::setBaseVelX(int estimate_mode, double vel)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   base_twist_.at(estimate_mode).vel.x(vel);
 }
 
-void StateEstimator::setBaseVelY(int estimate_mode, double vel) {
+void StateEstimator::setBaseVelY(int estimate_mode, double vel)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   base_twist_.at(estimate_mode).vel.y(vel);
 }
 
-void StateEstimator::setBaseVelZ(int estimate_mode, double vel) {
+void StateEstimator::setBaseVelZ(int estimate_mode, double vel)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   base_twist_.at(estimate_mode).vel.z(vel);
 }
 
-const KDL::Vector StateEstimator::getBaseAcc(int estimate_mode) {
+const KDL::Vector StateEstimator::getBaseAcc(int estimate_mode)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   return base_acc_.at(estimate_mode);
 }
 
-void StateEstimator::setBaseAcc(int estimate_mode, KDL::Vector acc) {
+void StateEstimator::setBaseAcc(int estimate_mode, KDL::Vector acc)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   base_acc_.at(estimate_mode) = acc;
 }
 
-const KDL::Rotation StateEstimator::getBaseOrientation(int estimate_mode) {
+const KDL::Rotation StateEstimator::getBaseOrientation(int estimate_mode)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   return base_pose_.at(estimate_mode).M;
 }
 
-void StateEstimator::setBaseOrientation(int estimate_mode, KDL::Rotation rot) {
+void StateEstimator::setBaseOrientation(int estimate_mode, KDL::Rotation rot)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   base_pose_.at(estimate_mode).M = rot;
 }
 
-const KDL::Vector StateEstimator::getBaseEuler(int estimate_mode) {
+const KDL::Vector StateEstimator::getBaseEuler(int estimate_mode)
+{
   KDL::Rotation rot = getBaseOrientation(estimate_mode);
   double r, p, y;
   rot.GetRPY(r, p, y);
   return KDL::Vector(r, p, y);
 }
 
-const KDL::Vector StateEstimator::getBaseAngularVel(int estimate_mode) {
+const KDL::Vector StateEstimator::getBaseAngularVel(int estimate_mode)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
 
   return base_twist_.at(estimate_mode).rot;
 }
 
-void StateEstimator::setBaseAngularVel(int estimate_mode, KDL::Vector omega) {
+void StateEstimator::setBaseAngularVel(int estimate_mode, KDL::Vector omega)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   base_twist_.at(estimate_mode).rot = omega;
 }
 
-const KDL::Frame StateEstimator::getCogPose(int estimate_mode) {
+const KDL::Frame StateEstimator::getCogPose(int estimate_mode)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   return cog_pose_.at(estimate_mode);
 }
 
-void StateEstimator::setCogPose(int estimate_mode, KDL::Frame pose) {
+void StateEstimator::setCogPose(int estimate_mode, KDL::Frame pose)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   cog_pose_.at(estimate_mode) = pose;
 }
 
-const KDL::Twist StateEstimator::getCogTwist(int estimate_mode) {
+const KDL::Twist StateEstimator::getCogTwist(int estimate_mode)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   return cog_twist_.at(estimate_mode);
 }
 
-void StateEstimator::setCogTwist(int estimate_mode, KDL::Twist twist) {
+void StateEstimator::setCogTwist(int estimate_mode, KDL::Twist twist)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   cog_twist_.at(estimate_mode) = twist;
 }
 
-const KDL::Vector StateEstimator::getCogPos(int estimate_mode) {
+const KDL::Vector StateEstimator::getCogPos(int estimate_mode)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   return cog_pose_.at(estimate_mode).p;
 }
 
-void StateEstimator::setCogPos(int estimate_mode, KDL::Vector pos) {
+void StateEstimator::setCogPos(int estimate_mode, KDL::Vector pos)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   cog_pose_.at(estimate_mode).p = pos;
 }
 
-const KDL::Vector StateEstimator::getCogVel(int estimate_mode) {
+const KDL::Vector StateEstimator::getCogVel(int estimate_mode)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   return cog_twist_.at(estimate_mode).vel;
 }
 
-void StateEstimator::setCogVel(int estimate_mode, KDL::Vector vel) {
+void StateEstimator::setCogVel(int estimate_mode, KDL::Vector vel)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   cog_twist_.at(estimate_mode).vel = vel;
 }
 
-const KDL::Vector StateEstimator::getCogAcc(int estimate_mode) {
+const KDL::Vector StateEstimator::getCogAcc(int estimate_mode)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   return cog_acc_.at(estimate_mode);
 }
 
-void StateEstimator::setCogAcc(int estimate_mode, KDL::Vector acc) {
+void StateEstimator::setCogAcc(int estimate_mode, KDL::Vector acc)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   cog_acc_.at(estimate_mode) = acc;
 }
 
-const KDL::Rotation StateEstimator::getCogOrientation(int estimate_mode) {
+const KDL::Rotation StateEstimator::getCogOrientation(int estimate_mode)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   return cog_pose_.at(estimate_mode).M;
 }
 
-void StateEstimator::setCogOrientation(int estimate_mode, KDL::Rotation rot) {
+void StateEstimator::setCogOrientation(int estimate_mode, KDL::Rotation rot)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   cog_pose_.at(estimate_mode).M = rot;
 }
 
-const KDL::Vector StateEstimator::getCogEuler(int estimate_mode) {
+const KDL::Vector StateEstimator::getCogEuler(int estimate_mode)
+{
   KDL::Rotation rot = getCogOrientation(estimate_mode);
   double r, p, y;
   rot.GetRPY(r, p, y);
   return KDL::Vector(r, p, y);
 }
 
-const KDL::Vector StateEstimator::getCogAngularVel(int estimate_mode) {
+const KDL::Vector StateEstimator::getCogAngularVel(int estimate_mode)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
 
   return cog_twist_.at(estimate_mode).rot;
 }
 
-void StateEstimator::setCogAngularVel(int estimate_mode, KDL::Vector omega) {
+void StateEstimator::setCogAngularVel(int estimate_mode, KDL::Vector omega)
+{
   std::lock_guard<std::mutex> lock(state_mutex_);
   cog_twist_.at(estimate_mode).rot = omega;
 }
 
-void StateEstimator::setBaseOrientationWxB(int estimate_mode, KDL::Vector v) {
+void StateEstimator::setBaseOrientationWxB(int estimate_mode, KDL::Vector v)
+{
   KDL::Vector wx_b = v;
   wx_b.Normalize();
 
@@ -520,7 +606,8 @@ void StateEstimator::setBaseOrientationWxB(int estimate_mode, KDL::Vector v) {
   setBaseOrientation(estimate_mode, rot_inv.Inverse());
 }
 
-void StateEstimator::setBaseOrientationWzB(int estimate_mode, KDL::Vector v) {
+void StateEstimator::setBaseOrientationWzB(int estimate_mode, KDL::Vector v)
+{
   KDL::Vector wz_b = v;
   wz_b.Normalize();
 
@@ -539,7 +626,8 @@ void StateEstimator::setBaseOrientationWzB(int estimate_mode, KDL::Vector v) {
   setBaseOrientation(estimate_mode, rot_inv.Inverse());
 }
 
-void StateEstimator::setCogOrientationWxB(int estimate_mode, KDL::Vector v) {
+void StateEstimator::setCogOrientationWxB(int estimate_mode, KDL::Vector v)
+{
   KDL::Vector wx_c = v;
   wx_c.Normalize();
 
@@ -558,7 +646,8 @@ void StateEstimator::setCogOrientationWxB(int estimate_mode, KDL::Vector v) {
   setCogOrientation(estimate_mode, rot_inv.Inverse());
 }
 
-void StateEstimator::setCogOrientationWzB(int estimate_mode, KDL::Vector v) {
+void StateEstimator::setCogOrientationWzB(int estimate_mode, KDL::Vector v)
+{
   KDL::Vector wz_c = v;
   wz_c.Normalize();
 
@@ -577,14 +666,17 @@ void StateEstimator::setCogOrientationWzB(int estimate_mode, KDL::Vector v) {
   setCogOrientation(estimate_mode, rot_inv.Inverse());
 }
 
-void StateEstimator::updateBaseQueue(const double timestamp, const KDL::Rotation r_ee, const KDL::Rotation r_ex, const KDL::Vector omega) {
+void StateEstimator::updateBaseQueue(const double timestamp, const KDL::Rotation r_ee, const KDL::Rotation r_ex,
+                                     const KDL::Vector omega)
+{
   std::lock_guard<std::mutex> lock(queue_mutex_);
   timestamp_qu_.push_back(timestamp);
   base_rot_ee_qu_.push_back(r_ee);
   base_rot_ex_qu_.push_back(r_ex);
   base_omega_qu_.push_back(omega);
 
-  if(timestamp_qu_.size() > qu_size_) {
+  if (timestamp_qu_.size() > qu_size_)
+  {
     timestamp_qu_.pop_front();
     base_rot_ee_qu_.pop_front();
     base_rot_ex_qu_.pop_front();
@@ -592,166 +684,180 @@ void StateEstimator::updateBaseQueue(const double timestamp, const KDL::Rotation
   }
 }
 
-bool StateEstimator::findBaseRotOmega(const double timestamp, const int mode, KDL::Rotation& r, KDL::Vector& omega, bool verbose) {
+bool StateEstimator::findBaseRotOmega(const double timestamp, const int mode, KDL::Rotation &r, KDL::Vector &omega,
+                                      bool verbose)
+{
   std::lock_guard<std::mutex> lock(queue_mutex_);
 
-  if(timestamp_qu_.size() == 0) {
-
-    if (verbose) {
-      RCLCPP_WARN(LOGGER,
-                  "estimation: no valid queue for timestamp to find proper r and omega");
+  if (timestamp_qu_.size() == 0)
+  {
+    if (verbose)
+    {
+      RCLCPP_WARN(LOGGER, "estimation: no valid queue for timestamp to find proper r and omega");
     }
 
     return false;
   }
 
-  if(timestamp < timestamp_qu_.front()) {
-    if (verbose) {
-      RCLCPP_WARN_STREAM(LOGGER,
-                         "estimation: sensor timestamp "
-                         << timestamp << " is earlier than the oldest timestamp "
-                         << timestamp_qu_.front() << " in queue");
+  if (timestamp < timestamp_qu_.front())
+  {
+    if (verbose)
+    {
+      RCLCPP_WARN_STREAM(LOGGER, "estimation: sensor timestamp "
+                                     << timestamp << " is earlier than the oldest timestamp " << timestamp_qu_.front()
+                                     << " in queue");
     }
     return false;
   }
 
-  if(timestamp > timestamp_qu_.back()) {
-    if (verbose) {
-      RCLCPP_WARN_STREAM(LOGGER,
-                        "estimation: sensor timestamp "
-                        << timestamp << " is later than the latest timestamp "
-                        << timestamp_qu_.back() << " in queue");
+  if (timestamp > timestamp_qu_.back())
+  {
+    if (verbose)
+    {
+      RCLCPP_WARN_STREAM(LOGGER, "estimation: sensor timestamp " << timestamp << " is later than the latest timestamp "
+                                                                 << timestamp_qu_.back() << " in queue");
     }
     return false;
   }
 
-  size_t candidate_index = (timestamp_qu_.size() - 1) * (timestamp - timestamp_qu_.front()) / (timestamp_qu_.back() - timestamp_qu_.front());
+  size_t candidate_index = (timestamp_qu_.size() - 1) * (timestamp - timestamp_qu_.front()) /
+                           (timestamp_qu_.back() - timestamp_qu_.front());
 
-  if(timestamp > timestamp_qu_.at(candidate_index)) {
-    for(auto it = timestamp_qu_.begin() + candidate_index; it != timestamp_qu_.end(); ++it) {
-      /* future timestamp, escape */
-      if(*it > timestamp) {
+  if (timestamp > timestamp_qu_.at(candidate_index))
+  {
+    for (auto it = timestamp_qu_.begin() + candidate_index; it != timestamp_qu_.end(); ++it)
+    {
+      /* Future timestamp, escape */
+      if (*it > timestamp)
+      {
         if (fabs(*it - timestamp) < fabs(*(it - 1) - timestamp))
           candidate_index = std::distance(timestamp_qu_.begin(), it);
         else
-          candidate_index = std::distance(timestamp_qu_.begin(), it-1);
+          candidate_index = std::distance(timestamp_qu_.begin(), it - 1);
 
-        //RCLCPP_INFO(LOGGER, "find timestamp sensor vs imu: [%f, %f], candidate: %d", timestamp, timestamp_qu_.at(candidate_index), candidate_index);
+        // RCLCPP_INFO(LOGGER, "find timestamp sensor vs imu: [%f, %f], candidate: %d", timestamp,
+        // timestamp_qu_.at(candidate_index), candidate_index);
         break;
       }
     }
-  } else {
-    for(auto it = timestamp_qu_.rbegin() + (timestamp_qu_.size() - 1 - candidate_index); it != timestamp_qu_.rend(); ++it) {
-      /* future timestamp, escape */
-      if(*it < timestamp) {
-        if (fabs(*it - timestamp) < fabs(*(it - 1) - timestamp)) {
+  }
+  else
+  {
+    auto reverse_index = timestamp_qu_.size() - 1 - candidate_index;
+    for (auto it = timestamp_qu_.rbegin() + reverse_index; it != timestamp_qu_.rend(); ++it)
+    {
+      /* Future timestamp, escape */
+      if (*it < timestamp)
+      {
+        if (fabs(*it - timestamp) < fabs(*(it - 1) - timestamp))
+        {
           candidate_index = timestamp_qu_.size() - 1 - std::distance(timestamp_qu_.rbegin(), it);
-        } else {
-          candidate_index = timestamp_qu_.size() - 1 - std::distance(timestamp_qu_.rbegin(), it-1);
+        }
+        else
+        {
+          candidate_index = timestamp_qu_.size() - 1 - std::distance(timestamp_qu_.rbegin(), it - 1);
         }
 
-        //RCLCPP_INFO(LOGGER, "reverse find timestamp sensor vs imu: [%f, %f], %d", timestamp, timestamp_qu_.at(candidate_index) , candidate_index);
+        // RCLCPP_INFO(LOGGER, "reverse find timestamp sensor vs imu: [%f, %f], %d", timestamp,
+        // timestamp_qu_.at(candidate_index) , candidate_index);
         break;
       }
     }
   }
 
   omega = base_omega_qu_.at(candidate_index);
-  switch(mode) {
-  case EGOMOTION_ESTIMATE:
-    r = base_rot_ee_qu_.at(candidate_index);
-    break;
-  case EXPERIMENT_ESTIMATE:
-    r = base_rot_ex_qu_.at(candidate_index);
-    break;
-  default:
-    RCLCPP_ERROR(LOGGER,
-                 "estimation search state with timestamp: wrong mode %d", mode);
-    return false;
+  switch (mode)
+  {
+    case EGOMOTION_ESTIMATE:
+      r = base_rot_ee_qu_.at(candidate_index);
+      break;
+    case EXPERIMENT_ESTIMATE:
+      r = base_rot_ex_qu_.at(candidate_index);
+      break;
+    default:
+      RCLCPP_ERROR(LOGGER, "estimation search state with timestamp: wrong mode %d", mode);
+      return false;
   }
 
   return true;
 }
 
-const double StateEstimator::getImuLatestTimeStamp() {
+const double StateEstimator::getImuLatestTimeStamp()
+{
   std::lock_guard<std::mutex> lock(queue_mutex_);
   return timestamp_qu_.back();
 }
 
-const FuserList& StateEstimator::getFuserList(int mode) {
-  return fuser_maps_.at(mode);
-}
+const FuserList &StateEstimator::getFuserList(int mode) { return fuser_maps_.at(mode); }
 
-/* set unhealth level */
-void StateEstimator::setUnhealthLevel(uint8_t unhealth_level) {
-  if(unhealth_level > unhealth_level_) unhealth_level_ = unhealth_level;
+/* Set unhealth level */
+void StateEstimator::setUnhealthLevel(uint8_t unhealth_level)
+{
+  if (unhealth_level > unhealth_level_) unhealth_level_ = unhealth_level;
 
   /* TODO: should write the solution for the unhealth sensor  */
 }
 
-void StateEstimator::process() {
-
-  /* check the heartbeat of each sensor */
+void StateEstimator::process()
+{
+  /* Check the heartbeat of each sensor */
   sensorHealthCheck();
 
-  /* publish */
+  /* Publish */
   publish();
 }
 
-void StateEstimator::sensorHealthCheck() {
-
-  for(auto& sensor: sensors_) {
+void StateEstimator::sensorHealthCheck()
+{
+  for (auto &sensor : sensors_)
+  {
     sensor->healthCheck();
   }
-
 }
 
-void StateEstimator::publish() {
-
+void StateEstimator::publish()
+{
   rclcpp::Time imu_stamp = imu_handlers_.at(0)->getTimeStamp();
 
-  if (imu_stamp.seconds() == 0) return; // not ready
+  if (imu_stamp.seconds() == 0) return;  // Not ready
 
   odomPublish(imu_stamp);
   tfBroadcast(imu_stamp);
   prev_pub_stamp_ = imu_stamp;
 }
 
-void StateEstimator::odomPublish(rclcpp::Time stamp) {
-
+void StateEstimator::odomPublish(rclcpp::Time stamp)
+{
   nav_msgs::msg::Odometry odom_state;
   odom_state.header.stamp = stamp;
   odom_state.header.frame_id = "world";
 
-  /* publish Baselink odometry */
+  /* Publish Baselink odometry */
   std::string base_name = robot_model_->getBaselinkName();
-  odom_state.child_frame_id
-    = tf_prefix_.empty() ? base_name : tf_prefix_ + "/" + base_name;
+  odom_state.child_frame_id = tf_prefix_.empty() ? base_name : tf_prefix_ + "/" + base_name;
   odom_state.pose.pose = tf2::toMsg(getBasePose(estimate_mode_));
-  odom_state.twist.twist =
-    aerial_robot_model::kdlToMsg(getBaseTwist(estimate_mode_));
+  odom_state.twist.twist = aerial_robot_model::kdlToMsg(getBaseTwist(estimate_mode_));
   baselink_odom_pub_->publish(odom_state);
 
-  /* publish CoG odometry */
+  /* Publish CoG odometry */
   odom_state.child_frame_id = tf_prefix_.empty() ? "cog" : tf_prefix_ + "/cog";
   odom_state.pose.pose = tf2::toMsg(getCogPose(estimate_mode_));
-  odom_state.twist.twist =
-    aerial_robot_model::kdlToMsg(getCogTwist(estimate_mode_));
+  odom_state.twist.twist = aerial_robot_model::kdlToMsg(getCogTwist(estimate_mode_));
   cog_odom_pub_->publish(odom_state);
 }
 
-void StateEstimator::tfBroadcast(rclcpp::Time stamp) {
-  /* avoid the redundant timestamp which induces annoying logs from TF server */
+void StateEstimator::tfBroadcast(rclcpp::Time stamp)
+{
+  /* Avoid the redundant timestamp which induces annoying logs from TF server */
   if (stamp.seconds() == prev_pub_stamp_.seconds()) return;
 
   const auto segments_tf = robot_model_->getSegmentsTf();
-  /* skip if kinemtiacs is not initialized */
-  if(segments_tf.size() == 0) return;
+  /* Skip if kinemtiacs is not initialized */
+  if (segments_tf.size() == 0) return;
 
   auto tf_base2root = segments_tf.at(robot_model_->getBaselinkName()).Inverse();
   auto tf_world2base = getBasePose(estimate_mode_);
-  geometry_msgs::msg::TransformStamped tf_msg
-    = aerial_robot_model::kdlToMsg(tf_world2base * tf_base2root);
+  geometry_msgs::msg::TransformStamped tf_msg = aerial_robot_model::kdlToMsg(tf_world2base * tf_base2root);
 
   tf_msg.header.stamp = stamp;
   tf_msg.header.frame_id = "world";
@@ -759,4 +865,3 @@ void StateEstimator::tfBroadcast(rclcpp::Time stamp) {
 
   br_->sendTransform(tf_msg);
 }
-

--- a/aerial_robot_humble.repos
+++ b/aerial_robot_humble.repos
@@ -4,11 +4,6 @@ repositories:
     url: "https://github.com/Box-Robotics/ros2_numpy.git"
     version: "humble"
     local-name: "ros2_numpy"
-  smach:
-    type: git
-    url: "https://github.com/ros/executive_smach.git"
-    version: "ros2"
-    local-name: "smach"
 
   kalman_filter:
     type: git

--- a/aerial_robot_model/CMakeLists.txt
+++ b/aerial_robot_model/CMakeLists.txt
@@ -100,10 +100,13 @@ target_include_directories(aerial_robot_model_ros
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
     )
-rosidl_target_interfaces(aerial_robot_model_ros
+rosidl_get_typesupport_target(cpp_typesupport_target
   ${PROJECT_NAME}
   "rosidl_typesupport_cpp"
-)  
+)
+target_link_libraries(aerial_robot_model_ros
+  "${cpp_typesupport_target}"
+)
 
 # --- robot_model plugin ----------------------------------------
 add_library(robot_model_plugin SHARED

--- a/aerial_robot_model/launch/aerial_robot_model_launch.py
+++ b/aerial_robot_model/launch/aerial_robot_model_launch.py
@@ -1,157 +1,177 @@
 #!/usr/bin/env python3
 import os
-
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, LogInfo
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, PythonExpression, Command, EnvironmentVariable
 from launch.conditions import IfCondition, UnlessCondition
-from launch.substitutions import (
-    LaunchConfiguration,
-    Command,
-    PathJoinSubstitution,
-    TextSubstitution,
-    FindExecutable,
-    PythonExpression
-)
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
-from launch_ros.parameter_descriptions import ParameterValue, ParameterFile
-from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.parameter_descriptions import ParameterValue
 
-from launch.actions import IncludeLaunchDescription
-from launch.substitutions import PathJoinSubstitution
+# ---------------------------------------------------------------------------
+# Argument declarations  (name, default, description, (optional) choices)
+# ---------------------------------------------------------------------------
+_ARGS = [
+    ("robot_model",      "hydrus",           "Name of the robot model ROS package"),
+    ("robot_ns",         "hydrus",           "Namespace for all robot nodes"),
+    ("real_machine",     "true",             "Use real machine specific bring-up inside model_launch", ["true", "false"]),
+    ("headless",         "true",             "Run without GUI", ["true", "false"]),
+    ("sim",              "false",            "Launch Gazebo simulation", ["true", "false"]),
+    ("robot_model_rviz", "rviz_config.rviz", "RViz config filename (resolved inside robot_model pkg/config/)"),
+]
+
+def gui_check(context, *args, **kwargs):
+    headless = LaunchConfiguration("headless").perform(context)
+    display = EnvironmentVariable("DISPLAY", default_value="").perform(context)
+    wayland_display = EnvironmentVariable("WAYLAND_DISPLAY", default_value="").perform(context)
+    xauthority = EnvironmentVariable("XAUTHORITY", default_value="").perform(context)
+    gui_available = PythonExpression([
+        "'true' if (len('", wayland_display, "') > 0) or ((len('", display, "') > 0) and (len('", xauthority, "') > 0)) else 'false'"
+    ]).perform(context)
+
+    if headless.lower() == "false" and gui_available.lower() == "false":
+        raise RuntimeError("[ERROR] [launch]: Headless mode is deactivated but no GUI environment detected. \
+                           Set headless to true or ensure DISPLAY and XAUTHORITY (X11) or \
+                           WAYLAND_DISPLAY (Wayland) are set in the environment.")
+    if headless.lower() == "false" and gui_available.lower() == "true":
+        if len(wayland_display) > 0:
+            print("[INFO] [launch]: GUI environment detected: Wayland (WAYLAND_DISPLAY is set)")
+        elif len(display) > 0 and len(xauthority) > 0:
+            print("[INFO] [launch]: GUI environment detected: X11 (DISPLAY and XAUTHORITY are set)")
+
 
 def generate_launch_description():
+    # ------------------------------------------------------------------
+    # 1.  Declare CLI-overridable arguments
+    # ------------------------------------------------------------------
+    declared_args = [
+        DeclareLaunchArgument(
+            name,
+            default_value=default_value,
+            description=description,
+            **({"choices": choices[0]} if choices else {})
+        )
+        for name, default_value, description, *choices in _ARGS
+    ]
 
-    # --- LaunchConfiguration ---
-    headless         = LaunchConfiguration('headless')
-    rm               = LaunchConfiguration('rm')
-    sim              = LaunchConfiguration('sim')
-    model_options    = LaunchConfiguration('model_options')
-    robot_model_pkg  = LaunchConfiguration('robot_model')
-    robot_ns         = LaunchConfiguration('robot_ns')
-    robot_model_rviz = LaunchConfiguration('robot_model_rviz')
-    robot_description_content = LaunchConfiguration('robot_description_content')
+    # Resolve / Read at launch time (NOT AT IMPORT TIME)
+    robot_model_pkg   = LaunchConfiguration("robot_model")
+    robot_ns          = LaunchConfiguration("robot_ns")
+    real_machine      = LaunchConfiguration("real_machine")
+    headless          = LaunchConfiguration("headless")
+    sim               = LaunchConfiguration("sim")
+    robot_model_rviz  = LaunchConfiguration("robot_model_rviz")
+    robot_description = LaunchConfiguration("robot_description")
 
-    # --- DeclareLaunchArgument ---
-    headless_arg = DeclareLaunchArgument(
-        'headless',
-        default_value='false',
-        description='Run without GUI (headless mode)'
-    )
+    # Guard against RViz/Qt crashes in headless environments (containers, SSH without X11/Wayland).
+    # We consider a GUI available if:
+    # - Wayland: WAYLAND_DISPLAY is set, OR
+    # - X11: DISPLAY and XAUTHORITY are both set.
+    display = EnvironmentVariable("DISPLAY", default_value="")
+    wayland_display = EnvironmentVariable("WAYLAND_DISPLAY", default_value="")
+    xauthority = EnvironmentVariable("XAUTHORITY", default_value="")
+    gui_available = PythonExpression([
+        "'true' if (len('", wayland_display, "') > 0) or ((len('", display, "') > 0) and (len('", xauthority, "') > 0)) else 'false'"
+    ])
+    launch_gui = PythonExpression([
+        "('", headless, "' == 'false') and ('", gui_available, "' == 'true')"
+    ])
 
-    simulation_arg = DeclareLaunchArgument(
-        'sim',
-        default_value='false',
-        description='Run in simulation mode (e.g., use Gazebo clock)'
-    )
-
-    realmachine_arg = DeclareLaunchArgument(
-        'rm',
-        default_value='false',
-        description='Run in realmachine mode'
-    )
-
-    model_options_arg = DeclareLaunchArgument(
-        'model_options',
-        default_value='',
-        description='Additional model options (e.g., extra URDF args)'
-    )
-
-    robot_model_pkg_arg = DeclareLaunchArgument(
-        'robot_model',
-        description='Name of the robot model package'
-    )
-
-    robot_ns_arg = DeclareLaunchArgument(
-        'robot_ns',
-        description='ROS namespace under which to launch the robot'
-    )
-
-    robot_model_rviz_arg = DeclareLaunchArgument(
-        'robot_model_rviz',
-        default_value='rviz_config.rviz',
-        description='RViz display configuration for the robot model'
-    )
-
-    robot_description_arg = DeclareLaunchArgument(
-        'robot_description_content',
-        description='Full robot_description (xacro output) from parent'
-    )
-
-    # --- robot description parameter ---w
-    robot_description = {
-            'robot_description':
-        ParameterValue(
-            robot_description_content,
+    robot_description_param = {
+        "robot_description": ParameterValue(
+            Command(robot_description),
             value_type=str
         )
     }
 
-    # --- rviz config path ---w
-    rviz_config = PathJoinSubstitution([
-        FindPackageShare(robot_model_pkg),
-        'config',
-        robot_model_rviz
-    ])
-
-    # --- joint state condition parameter---
+    # TODO WHAT IS THIS!? how can we have both sim and real_machine false at the same time? What does this represent? Necessary?
     need_js = PythonExpression([
-        "'false' if '", sim, "' == 'true' or '", rm, "' == 'true' else 'true'"
+        "'false' if '", sim, "' == 'true' or '", real_machine, "' == 'true' else 'true'"
     ])
 
-    # --- nodes ---
+    # ------------------------------------------------------------------
+    # 2.  Derived paths
+    # ------------------------------------------------------------------
+    rviz_config_path = PathJoinSubstitution([
+        FindPackageShare(robot_model_pkg),
+        "config", robot_model_rviz
+    ])
+
+    # ------------------------------------------------------------------
+    # 3.  Nodes
+    # ------------------------------------------------------------------
     robot_state_publisher_node = Node(
-        package='robot_state_publisher',
-        executable='robot_state_publisher',
-        name='robot_state_publisher',
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        name="robot_state_publisher",
         namespace=robot_ns,
         parameters=[
-            robot_description,
-            {'use_sim_time': sim, 'tf_prefix': robot_ns}
+            {
+                "tf_prefix": robot_ns,
+                "use_sim_time": sim
+            },
+            robot_description_param,
         ]
     )
 
     rotor_tf_publisher_node = Node(
-        package='aerial_robot_model',
-        executable='rotor_tf_publisher',
-        name='rotor_tf_publisher',
+        package="aerial_robot_model",
+        executable="rotor_tf_publisher",
+        name="rotor_tf_publisher",
         namespace=robot_ns,
         condition=UnlessCondition(need_js),
         parameters=[
-            {'use_sim_time': sim, 'tf_prefix': robot_ns},
-            robot_description],
+            {
+                "tf_prefix": robot_ns,
+                "use_sim_time": sim
+            },
+            robot_description_param
+        ],
     )
 
     joint_state_pub_node = Node(
-        package='joint_state_publisher_gui',
-        executable='joint_state_publisher_gui',
-        name='joint_state_publisher_gui',
+        package="joint_state_publisher_gui",
+        executable="joint_state_publisher_gui",
+        name="joint_state_publisher_gui",
         namespace=robot_ns,
         condition=IfCondition(need_js),
-        parameters=[{'use_sim_time': sim}, robot_description],
+        parameters=[
+            {
+                "use_sim_time": sim
+            },
+            robot_description_param
+        ],
     )
 
     rviz2_node = Node(
-        package='rviz2',
-        executable='rviz2',
-        name='rviz2',
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
         namespace=robot_ns,
-        arguments=['-d', rviz_config],
-        condition=UnlessCondition(headless),
-        parameters=[{'use_sim_time': sim}],
+        arguments=[
+            "-d", rviz_config_path
+        ],
+        condition=IfCondition(launch_gui),
+        parameters=[
+            {
+                "use_sim_time": sim
+            }
+        ],
+        output="screen"
     )
 
+    # ------------------------------------------------------------------
+    # 4.  Assemble LaunchDescription
+    # ------------------------------------------------------------------
     ld = LaunchDescription()
-    ld.add_action(headless_arg)
-    ld.add_action(simulation_arg)
-    ld.add_action(realmachine_arg)
-    ld.add_action(model_options_arg)
-    ld.add_action(robot_model_pkg_arg)
-    ld.add_action(robot_ns_arg)
-    ld.add_action(robot_model_rviz_arg)
-    ld.add_action(robot_description_arg)
+
+    for arg in declared_args:
+        ld.add_action(arg)
+
+    ld.add_action(OpaqueFunction(function=gui_check))
     ld.add_action(robot_state_publisher_node)
     ld.add_action(rotor_tf_publisher_node)
     ld.add_action(joint_state_pub_node)
     ld.add_action(rviz2_node)
+
     return ld

--- a/aerial_robot_nerve/spinal/CMakeLists.txt
+++ b/aerial_robot_nerve/spinal/CMakeLists.txt
@@ -68,7 +68,7 @@ add_library(spinal_math
   ${SPINAL_DIRS}/math/vector2.cpp
   ${SPINAL_DIRS}/math/vector3.cpp
   ${SPINAL_DIRS}/math/quaternion.cpp
-  # ${SPINAL_DIRS}/math/location.cpp
+  ${SPINAL_DIRS}/math/location.cpp
   )
 
 

--- a/aerial_robot_nerve/spinal/mcu_project/lib/My_Lib/math/vector3.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/My_Lib/math/vector3.h
@@ -26,7 +26,7 @@
  *          18-12-2003
  *          06-06-2004
  *
- * © 2003, This code is provided "as is" and you can use it freely as long as
+ * ï¿½ 2003, This code is provided "as is" and you can use it freely as long as
  * credit is given to Bill Perone in the application it is used in
  *
  * Notes:
@@ -53,6 +53,7 @@
 #include <float.h>
 #include <math.h>
 #include <string.h>
+#include "rotations.h"
 
 #if MATH_CHECK_INDEXES
 #include <assert.h>

--- a/aerial_robot_simulation/CMakeLists.txt
+++ b/aerial_robot_simulation/CMakeLists.txt
@@ -41,7 +41,7 @@ include_directories(
   include
   )
 
-# rotor handle lib
+# Rotor handle lib
 add_library(rotor_handle_lib INTERFACE)
 target_include_directories(rotor_handle_lib INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -54,7 +54,7 @@ ament_target_dependencies(rotor_handle_lib INTERFACE
   aerial_robot_model
 )
 
-# spinal interface
+# Spinal interface
 add_library(spinal_interface SHARED
   src/spinal_interface.cpp
 )

--- a/aerial_robot_simulation/launch/gazebo_launch.py
+++ b/aerial_robot_simulation/launch/gazebo_launch.py
@@ -1,117 +1,143 @@
+#!/usr/bin/env python3
 import os
 from launch import LaunchDescription
-from launch.conditions import IfCondition
-from launch.actions import DeclareLaunchArgument, ExecuteProcess, SetEnvironmentVariable, IncludeLaunchDescription, RegisterEventHandler, Shutdown
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, EnvironmentVariable, TextSubstitution, PythonExpression
-from launch_ros.substitutions import FindPackageShare, FindPackagePrefix
-from launch_ros.actions import Node
-from launch_ros.parameter_descriptions import ParameterValue, ParameterFile
-from ament_index_python.packages import get_package_share_directory
+from launch.actions import (
+    DeclareLaunchArgument,
+    ExecuteProcess,
+    SetEnvironmentVariable,
+    RegisterEventHandler,
+    Shutdown
+)
+from launch.substitutions import (
+    LaunchConfiguration,
+    PathJoinSubstitution,
+    PythonExpression,
+    TextSubstitution,
+    EnvironmentVariable,
+)
+from launch.conditions import UnlessCondition
 from launch.event_handlers import OnProcessExit
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackagePrefix
+from ament_index_python.packages import get_package_share_directory
+
+# ---------------------------------------------------------------------------
+# Argument declarations  (name, default, description, (optional) choices)
+# ---------------------------------------------------------------------------
+pkg_share   = get_package_share_directory("aerial_robot_simulation")
+default_world = os.path.join(pkg_share, "gazebo_model", "world", "empty.world")
+_ARGS = [
+    ("robot_ns",       "hydrus",      "Namespace for all robot nodes"),
+    ("world_sdf_file", default_world, "Ignition world SDF file path (default: empty world included in this package)"),
+    ("headless",       "true",        "Run without GUI", ["true", "false"]),
+    ("sim_param_path", "",            "Path to YAML file with simulation parameters"),
+    ("spawn_x",        "0.0",         "Gazebo spawn X position [m] (sim only)"),
+    ("spawn_y",        "0.0",         "Gazebo spawn Y position [m] (sim only)"),
+    ("spawn_z",        "0.5",         "Gazebo spawn Z position [m] (sim only)"),
+]
 
 def generate_launch_description():
+    # ------------------------------------------------------------------
+    # 1.  Declare CLI-overridable arguments
+    # ------------------------------------------------------------------
+    declared_args = [
+        DeclareLaunchArgument(
+            name,
+            default_value=default_value,
+            description=description,
+            **({"choices": choices[0]} if choices else {})
+        )
+        for name, default_value, description, *choices in _ARGS
+    ]
 
-    # --- Load directory path ---
-    pkg_share   = get_package_share_directory('aerial_robot_simulation')
-    default_world = os.path.join(pkg_share, 'gazebo_model', 'world', 'empty.world')
-
-    # --- LaunchConfiguration ---
-    world        = LaunchConfiguration('world_sdf_file')
-    robot_name   = LaunchConfiguration('robot_name')
-    spawn_x = LaunchConfiguration('spawn_x')
-    spawn_y = LaunchConfiguration('spawn_y')
-    spawn_z = LaunchConfiguration('spawn_z')
-    sim_param_file = LaunchConfiguration('sim_param_file')
-    headless = LaunchConfiguration('headless')
-
-    # --- DeclareLaunchArgument ---
-    world_arg = DeclareLaunchArgument(
-        'world_sdf_file',
-        default_value=default_world,
-        description='Ignition world file'
-    )
-    robot_name_arg = DeclareLaunchArgument(
-        'robot_name',
-        default_value='',
-        description='Entity name for spawn'
-    )
-    spawn_x_arg = DeclareLaunchArgument(
-        'spawn_x',
-        default_value='0.0',
-        description='Initial X position'
-    )
-    spawn_y_arg = DeclareLaunchArgument(
-        'spawn_y',
-        default_value='0.0',
-        description='Initial Y position'
-    )
-    spawn_z_arg = DeclareLaunchArgument(
-        'spawn_z',
-        default_value='0.5',
-        description='Initial Z position'
-    )
-    sim_param_file_arg = DeclareLaunchArgument(
-        'sim_param_file',
-        default_value='',
-        description='Path to the simulation parameter YAML file'
-    )
-
-    headless_arg = DeclareLaunchArgument(
-        'headless',
-        default_value='False',
-        description='Run without GUI (headless mode)'
-    )
+    # Resolve / Read at launch time (NOT AT IMPORT TIME)
+    robot_ns       = LaunchConfiguration("robot_ns")
+    world          = LaunchConfiguration("world_sdf_file")
+    headless       = LaunchConfiguration("headless")
+    sim_param_path = LaunchConfiguration("sim_param_path")
+    spawn_x        = LaunchConfiguration("spawn_x")
+    spawn_y        = LaunchConfiguration("spawn_y")
+    spawn_z        = LaunchConfiguration("spawn_z")
     
-    # --- environmental setting ---
-    robot_prefix = FindPackagePrefix(robot_name)
-    robot_share_dir = PathJoinSubstitution([robot_prefix, 'share'])
+    # ------------------------------------------------------------------
+    # 2.  Derived paths & environment variables
+    # ------------------------------------------------------------------    
+    robot_share_dir = PathJoinSubstitution([FindPackagePrefix(robot_ns), "share"])
+
+    # Pass through DISPLAY env var for Gazebo GUI (if not headless)
     set_env = SetEnvironmentVariable(
-        'DISPLAY', os.environ.get('DISPLAY','')
+        name="DISPLAY",
+        value=os.environ.get("DISPLAY","")
+    )
+    set_xauthority = SetEnvironmentVariable(
+        name="XAUTHORITY",
+        value=os.environ.get("XAUTHORITY", os.path.expanduser("~/.Xauthority"))
     )
 
-    set_ign_resource_path = SetEnvironmentVariable(
-        name='GZ_SIM_RESOURCE_PATH',
+    # Gazebo looks for models, worlds, and plugins in GZ_SIM_RESOURCE_PATH
+    set_gazebo_resource_path = SetEnvironmentVariable(
+        name="GZ_SIM_RESOURCE_PATH",
         value=[
-            EnvironmentVariable('GZ_SIM_RESOURCE_PATH', default_value=''),
-            TextSubstitution(text=':'),
+            EnvironmentVariable("GZ_SIM_RESOURCE_PATH", default_value=""),
+            TextSubstitution(text=":"),
             robot_share_dir
         ]
     )
 
-    set_ign_default_path = SetEnvironmentVariable(
-        name='GZ_SIM_SYSTEM_PLUGIN_PATH',
+    set_gazebo_default_path = SetEnvironmentVariable(
+        name="GZ_SIM_SYSTEM_PLUGIN_PATH",
         value=[
-            TextSubstitution(text='/opt/ros/humble/lib'),
+            TextSubstitution(text="/opt/ros/humble/lib"),
             TextSubstitution(text=os.pathsep),
-            EnvironmentVariable('GZ_SIM_SYSTEM_PLUGIN_PATH', default_value=''),
+            EnvironmentVariable("GZ_SIM_SYSTEM_PLUGIN_PATH", default_value=""),
+        ]
+    )
+
+    # Fortress (`ign gazebo`) uses IGN_GAZEBO_* env vars
+    set_ignition_resource_path = SetEnvironmentVariable(
+        name="IGN_GAZEBO_RESOURCE_PATH",
+        value=[
+            EnvironmentVariable("IGN_GAZEBO_RESOURCE_PATH", default_value=""),
+            TextSubstitution(text=":"),
+            robot_share_dir,
+        ]
+    )
+
+    set_ignition_default_path = SetEnvironmentVariable(
+        name="IGN_GAZEBO_SYSTEM_PLUGIN_PATH",
+        value=[
+            TextSubstitution(text="/opt/ros/humble/lib"),
+            TextSubstitution(text=os.pathsep),
+            EnvironmentVariable("IGN_GAZEBO_SYSTEM_PLUGIN_PATH", default_value=""),
         ]
     )
 
     set_fastrtps_profile = SetEnvironmentVariable(
-        'FASTRTPS_DEFAULT_PROFILES_FILE',
-        os.path.join(pkg_share, 'config', 'fastrtps_profiles.xml')
+        name="FASTRTPS_DEFAULT_PROFILES_FILE",
+        value=os.path.join(pkg_share, "config", "fastrtps_profiles.xml")
     )
 
-    # --- Gazebo ---
+    # ------------------------------------------------------------------
+    # 3.  Execute Gazebo processes
+    # ------------------------------------------------------------------ 
     ign_server = ExecuteProcess(
         cmd=[
-            'ign', 'gazebo',
-            '-r',                     
-            '-s', 'libgazebo_ros_factory.so',
-            '-s', 'libgazebo_ros_init.so',
+            "ign", "gazebo",
+            "-r",                     
+            "-s", "libgazebo_ros_factory.so",
+            "-s", "libgazebo_ros_init.so",
             world
         ],
-        output='screen',
+        output="screen"
     )
 
     ign_client = ExecuteProcess(
         cmd=[
-            'ign', 'gazebo',
-            '-g',
+            "ign", "gazebo",
+            "-g",
         ],
-        condition=IfCondition(PythonExpression(
-            ['not ', headless])),        
-        output='screen',
+        condition=UnlessCondition(headless),
+        output="screen"
     )
 
     shutdown_handler = RegisterEventHandler(
@@ -121,77 +147,85 @@ def generate_launch_description():
         )
     )
 
-    # --- Nodes ---
+    # ------------------------------------------------------------------
+    # 3.  Nodes
+    # ------------------------------------------------------------------
     sim_param_server = Node(
-        package='aerial_robot_simulation',
-        executable='sim_param_server',
-        name='sim_param_server',
-        namespace= robot_name,
-        parameters=[sim_param_file,
-        ],
+        package="aerial_robot_simulation",
+        executable="sim_param_server",
+        name="sim_param_server",
+        namespace= robot_ns,
+        parameters=[
+            sim_param_path
+        ]
     )
 
     clock_bridge = Node(
-        package='ros_gz_bridge',
-        executable='parameter_bridge',
+        package="ros_gz_bridge",
+        executable="parameter_bridge",
         arguments=[
-            '/clock@rosgraph_msgs/msg/Clock[ignition.msgs.Clock'
+            "/clock@rosgraph_msgs/msg/Clock[ignition.msgs.Clock"
         ],
-        output='screen'
+        output="screen"
     )
     
     spawn_robot = Node(
-        package='ros_gz_sim',
-        executable='create',
+        package="ros_gz_sim",
+        executable="create",
         arguments=[
-            '-name',  robot_name,
-            '-topic', PythonExpression(["'/' + '", robot_name, "' + '/robot_description'"]),
-            '-x', spawn_x,
-            '-y', spawn_y,
-            '-z', spawn_z,
+            "-name", robot_ns,
+            "-topic", PythonExpression(["'/' + '", robot_ns, "' + '/robot_description'"]),
+            "-x", spawn_x,
+            "-y", spawn_y,
+            "-z", spawn_z,
         ],
-        output='screen',
+        output="screen"
     )
 
     att_controller_spawner = Node(
-        namespace= robot_name,
-        package='controller_manager',
-        executable='spawner',
-        name='spawn_att_controller',
-        output='screen',
+        namespace=robot_ns,
+        package="controller_manager",
+        executable="spawner",
+        name="spawn_att_controller",
+        output="screen",
         arguments=[
-            'attitude_controller',
-            '--param-file', sim_param_file
+            "attitude_controller",
+            "--param-file", sim_param_path
         ],
-        parameters=[{'use_sim_time': True}]
+        parameters=[
+            {"use_sim_time": True}
+        ]
     )
 
     joint_state_broadcaster_spawner = Node(
-        namespace= robot_name,
-        package='controller_manager',
-        executable='spawner',
-        arguments=['joint_state_broadcaster'],
-        parameters=[{'use_sim_time': True}],
+        namespace=robot_ns,
+        package="controller_manager",
+        executable="spawner",
+        arguments=["joint_state_broadcaster"],
+        parameters=[
+            {"use_sim_time": True}
+        ]
     )
 
     ld = LaunchDescription()
-    ld.add_action(world_arg)
-    ld.add_action(robot_name_arg)
-    ld.add_action(spawn_x_arg)
-    ld.add_action(spawn_y_arg)
-    ld.add_action(spawn_z_arg)
-    ld.add_action(sim_param_file_arg)
-    ld.add_action(set_fastrtps_profile)
+    
+    for arg in declared_args:
+        ld.add_action(arg)
+
     ld.add_action(set_env)
-    ld.add_action(set_ign_resource_path)
-    ld.add_action(set_ign_default_path)
+    ld.add_action(set_xauthority)
+    ld.add_action(set_gazebo_resource_path)
+    ld.add_action(set_gazebo_default_path)
+    ld.add_action(set_ignition_resource_path)
+    ld.add_action(set_ignition_default_path)
+    ld.add_action(set_fastrtps_profile)
+    ld.add_action(shutdown_handler)
     ld.add_action(sim_param_server)
     ld.add_action(ign_server)
-    ld.add_action(shutdown_handler)
     ld.add_action(ign_client)
     ld.add_action(clock_bridge)
     ld.add_action(spawn_robot)
-    ld.add_action(joint_state_broadcaster_spawner)
     ld.add_action(att_controller_spawner)
+    ld.add_action(joint_state_broadcaster_spawner)
 
     return ld

--- a/pre-commit/.clang-format
+++ b/pre-commit/.clang-format
@@ -1,0 +1,68 @@
+# .clang-format
+Language: Cpp
+BasedOnStyle: Google
+
+AccessModifierOffset: -2                              # Indent offset for public/protected/private labels
+AlignEscapedNewlinesLeft: false                       # Left-align escaped newlines in strings
+AlignOperands: true                                   # Align operators if they do wrap
+AlignTrailingComments: true                           # Align trailing // or # comments vertically
+AllowAllParametersOfDeclarationOnNextLine: false      # Always insert a line break for each parameter
+AllowShortFunctionsOnASingleLine: All                 # Collapse function bodies to a single line if possible
+AllowShortIfStatementsOnASingleLine: true             # Collapse if-bodies for short if statements
+AllowShortLambdasOnASingleLine: All                   # Collapse lambda bodies to a single lime if possible
+AllowShortLoopsOnASingleLine: true                    # Collapse loop-bodies for short loops
+AlwaysBreakTemplateDeclarations: No                   # Force template declarations to break onto new lines
+AlwaysBreakBeforeMultilineStrings: true               # Break before multi-line string literals
+BinPackParameters: true                               # Pack parameters/arguments when they fit
+BreakBeforeBinaryOperators: false                     # Prefer breaking before operators
+BreakBeforeBraces: Custom                             # Use custom brace wrapping rules (see BraceWrapping)
+BreakBeforeTernaryOperators: false                    # Prefer breaking before ?: operators
+BreakConstructorInitializersBeforeComma: false        # Prefer breaking ctor initializer list before commas
+ColumnLimit: 120                                      # Maximum line length
+ConstructorInitializerAllOnOneLineOrOnePerLine: true  # Either one-line init list or one-per-line
+ConstructorInitializerIndentWidth: 2                  # Indent width for constructor initializer lists
+ContinuationIndentWidth: 4                            # Indent width for wrapped lines
+Cpp11BracedListStyle: false                           # Force C++11 braced-list formatting style
+DerivePointerBinding: false                           # Auto-derive pointer/reference binding style
+ExperimentalAutoDetectBinPacking: false               # Experimental bin-packing auto-detection
+IndentCaseLabels: true                                # Indent case/default labels within switch
+IndentFunctionDeclarationAfterType: false             # Indent function name after return type
+IndentWidth: 2                                        # Indent size for each block
+MaxEmptyLinesToKeep: 2                                # Collapse multiple blank lines
+NamespaceIndentation: None                            # Indent code inside namespaces (to avoid excessive indent we disable it)
+ObjCSpaceBeforeProtocolList: true                     # Space before Objective-C protocol lists
+PenaltyBreakAssignment: 200                           # Cost of breaking around an assignment operator
+PenaltyBreakBeforeFirstCallParameter: 19              # Cost of breaking before first call parameter
+PenaltyBreakComment: 20                               # Cost of breaking comments
+PenaltyBreakTemplateDeclaration: 100                  # Cost of breaking before template declarations
+PenaltyBreakFirstLessLess: 0                         # Cost of breaking << chains early
+PenaltyBreakString: 1000000                             # Cost of breaking string literals
+PenaltyExcessCharacter: 1000                          # Cost of exceeding ColumnLimit
+PenaltyReturnTypeOnItsOwnLine: 1000                   # Cost of placing return type on its own line
+PointerBindsToType: false                             # Bind * and & to the type (e.g., int* p) OR to the variable (e.g., int *p)
+SortIncludes: false                                   # Reorder #include directives
+SpaceAfterCStyleCast: false                           # Insert space after C-style casts: (T)x
+SpaceAfterControlStatementKeyword: true               # Insert space after if/for/while keywords
+SpaceBeforeAssignmentOperators: true                  # Insert spaces around assignment operators
+SpaceInEmptyParentheses: false                        # Insert space in empty parens: f()
+SpacesBeforeTrailingComments: 2                       # Insert spaces before trailing comments
+SpacesInAngles: false                                 # Insert spaces inside <...> template brackets
+SpacesInCStyleCastParentheses: false                  # Insert spaces inside C-style cast parens
+SpacesInParentheses: false                            # Insert spaces inside ( ... )
+Standard: Auto                                        # Choose formatting rules based on detected language
+TabWidth: 2                                           # Visual width of a tab character
+UseTab: Never                                         # Insert literal tab characters
+
+
+BraceWrapping:                                        # Fine-grained brace placement rules
+  AfterClass: true                                    # Put class opening brace on new line
+  AfterControlStatement: 'true'                       # Put control-statement brace on new line
+  AfterEnum: true                                     # Put enum opening brace on new line
+  AfterFunction: true                                 # Put function opening brace on new line
+  AfterNamespace: true                                # Put namespace opening brace on new line
+  AfterStruct: true                                   # Put struct opening brace on new line
+  AfterUnion: true                                    # Put union opening brace on new line
+  BeforeCatch: true                                   # Put catch on new line (after } )
+  BeforeElse: true                                    # Put else on new line (after } )
+  BeforeLambdaBody: true                              # Put lambda opening brace on new line
+  IndentBraces: false                                 # Indent the braces themselves

--- a/pre-commit/capitalize_cpp_comments.py
+++ b/pre-commit/capitalize_cpp_comments.py
@@ -113,22 +113,35 @@ def process_source(source: str) -> str:
     """Return *source* with all comments capitalised."""
     result = []
     prev_end = 0
+    last_was_line_comment = False
 
     for m in _TOKEN_RE.finditer(source):
         # Emit the literal text between the previous token and this one
-        result.append(source[prev_end : m.start()])
+        gap = source[prev_end : m.start()]
+        result.append(gap)
         prev_end = m.end()
 
         kind = m.lastgroup
         raw = m.group()
 
         if kind == "line":
-            result.append(_process_line_comment(raw))
+            is_continuation = False
+            if last_was_line_comment and (not gap or gap.isspace()):
+                if gap.count("\n") <= 1:
+                    is_continuation = True
+            
+            if is_continuation:
+                result.append(raw)
+            else:
+                result.append(_process_line_comment(raw))
+            last_was_line_comment = True
         elif kind == "block":
             result.append(_process_block_comment(raw))
+            last_was_line_comment = False
         else:
             # string, rawstring – emit verbatim
             result.append(raw)
+            last_was_line_comment = False
 
     # Tail after the last token
     result.append(source[prev_end:])

--- a/pre-commit/capitalize_cpp_comments.py
+++ b/pre-commit/capitalize_cpp_comments.py
@@ -5,9 +5,9 @@ capitalize_comments.py
 Pre-commit hook that capitalizes the first letter of every C++ comment.
 
 Handles:
-  - Single-line comments  : // some text  →  // Some text
-  - Inline comments       : int x; // note  →  int x; // Note
-  - Block comments        : /* text */  →  /* Text */
+  - Single-line comments  : // some text  ->  // Some text
+  - Inline comments       : int x; // note  ->  int x; // Note
+  - Block comments        : /* text */  ->  /* Text */
   - Multi-line block comments (each line's leading text is capitalized)
 
 Usage (called by pre-commit):
@@ -53,14 +53,22 @@ _TOKEN_RE = re.compile(
 
 def _capitalize_comment_text(text: str) -> str:
     """Uppercase the very first alphabetic character in *text*."""
+    stripped = text.lstrip(" \t")
+    if not stripped:
+        return text
+    # If the first non-whitespace character is not alphabetic (e.g. '<', '.',
+    # '(', '-', '1'), do not attempt capitalization.
+    if not stripped[0].isalpha():
+        return text
+
     # Do not capitalize if the very first word in the comment contains an
     # underscore, as it is likely a variable name or commented-out code.
-    m = re.search(r'[a-zA-Z_]\w*', text)
+    m = re.search(r"[a-zA-Z_]\w*", text)
     if m:
-        if '_' in m.group(0):
+        if "_" in m.group(0):
             return text
-        if m.group(0).lower() == 'ros':
-            return text[:m.start()] + 'ROS' + text[m.end():]
+        if m.group(0).lower() == "ros":
+            return text[: m.start()] + "ROS" + text[m.end() :]
 
     for i, ch in enumerate(text):
         if ch.isalpha():
@@ -70,10 +78,10 @@ def _capitalize_comment_text(text: str) -> str:
 
 def _process_line_comment(raw: str) -> str:
     """Capitalise a // comment, preserving the // prefix and any leading spaces."""
-    # raw starts with '//'
+    # Raw starts with '//'
     prefix = "//"
     rest = raw[len(prefix) :]
-    # preserve leading whitespace after //
+    # Preserve leading whitespace after //
     stripped = rest.lstrip(" \t")
     leading = rest[: len(rest) - len(stripped)]
     return prefix + leading + _capitalize_comment_text(stripped)
@@ -86,7 +94,7 @@ def _process_block_comment(raw: str) -> str:
     """
     # Split into /* , body , */
     assert raw.startswith("/*") and raw.endswith("*/")
-    inner = raw[2:-2]  # everything between /* and */
+    inner = raw[2:-2]  # Everything between /* and */
 
     lines = inner.split("\n")
     result_lines = []
@@ -129,7 +137,7 @@ def process_source(source: str) -> str:
             if last_was_line_comment and (not gap or gap.isspace()):
                 if gap.count("\n") <= 1:
                     is_continuation = True
-            
+
             if is_continuation:
                 result.append(raw)
             else:
@@ -139,7 +147,7 @@ def process_source(source: str) -> str:
             result.append(_process_block_comment(raw))
             last_was_line_comment = False
         else:
-            # string, rawstring – emit verbatim
+            # String, rawstring – emit verbatim
             result.append(raw)
             last_was_line_comment = False
 
@@ -151,6 +159,7 @@ def process_source(source: str) -> str:
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
+
 
 def main() -> int:
     if len(sys.argv) < 2:

--- a/pre-commit/capitalize_cpp_comments.py
+++ b/pre-commit/capitalize_cpp_comments.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""
+capitalize_comments.py
+
+Pre-commit hook that capitalizes the first letter of every C++ comment.
+
+Handles:
+  - Single-line comments  : // some text  →  // Some text
+  - Inline comments       : int x; // note  →  int x; // Note
+  - Block comments        : /* text */  →  /* Text */
+  - Multi-line block comments (each line's leading text is capitalized)
+
+Usage (called by pre-commit):
+    python capitalize_comments.py <file1> [file2 ...]
+"""
+
+import re
+import sys
+
+
+# ---------------------------------------------------------------------------
+# Tokeniser
+# ---------------------------------------------------------------------------
+
+# We split the source into alternating "non-comment" and "comment" chunks so
+# that we never accidentally capitalise string literals that happen to contain
+# comment-like sequences.
+
+_TOKEN_RE = re.compile(
+    r"""
+    # --- string / char literals (skip entirely) ---
+    (?P<string>
+        "(?:[^"\\]|\\.)*"       # double-quoted string
+      | '(?:[^'\\]|\\.)*'       # single-quoted char
+    )
+    |
+    # --- raw string literal R"delim(...)delim" ---
+    (?P<rawstring>
+        R"(?P<delim>[^()\\ \t\v\f\n]*)\(
+        .*?
+        \)(?P=delim)"
+    )
+    |
+    # --- block comment ---
+    (?P<block>/\*.*?\*/)
+    |
+    # --- line comment (to end of line, NOT consuming the newline) ---
+    (?P<line>//[^\n]*)
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+def _capitalize_comment_text(text: str) -> str:
+    """Uppercase the very first alphabetic character in *text*."""
+    # Do not capitalize if the very first word in the comment contains an
+    # underscore, as it is likely a variable name or commented-out code.
+    m = re.search(r'[a-zA-Z_]\w*', text)
+    if m:
+        if '_' in m.group(0):
+            return text
+        if m.group(0).lower() == 'ros':
+            return text[:m.start()] + 'ROS' + text[m.end():]
+
+    for i, ch in enumerate(text):
+        if ch.isalpha():
+            return text[:i] + ch.upper() + text[i + 1 :]
+    return text
+
+
+def _process_line_comment(raw: str) -> str:
+    """Capitalise a // comment, preserving the // prefix and any leading spaces."""
+    # raw starts with '//'
+    prefix = "//"
+    rest = raw[len(prefix) :]
+    # preserve leading whitespace after //
+    stripped = rest.lstrip(" \t")
+    leading = rest[: len(rest) - len(stripped)]
+    return prefix + leading + _capitalize_comment_text(stripped)
+
+
+def _process_block_comment(raw: str) -> str:
+    """Capitalise text inside a /* … */ block comment.
+
+    Strategy: capitalise the first alphabetic character in the entire block
+    """
+    # Split into /* , body , */
+    assert raw.startswith("/*") and raw.endswith("*/")
+    inner = raw[2:-2]  # everything between /* and */
+
+    lines = inner.split("\n")
+    result_lines = []
+    capitalized = False
+
+    for line in lines:
+        if not capitalized:
+            # Decorative prefix patterns like " * ", " *", leading spaces
+            m = re.match(r"^([ \t]*\*?[ \t]*)(.*?)(\s*)$", line, re.DOTALL)
+            if m:
+                lead, body, trail = m.group(1), m.group(2), m.group(3)
+                result_lines.append(lead + _capitalize_comment_text(body) + trail)
+                if any(c.isalpha() for c in body):
+                    capitalized = True
+            else:
+                result_lines.append(line)
+        else:
+            result_lines.append(line)
+
+    return "/*" + "\n".join(result_lines) + "*/"
+
+
+def process_source(source: str) -> str:
+    """Return *source* with all comments capitalised."""
+    result = []
+    prev_end = 0
+
+    for m in _TOKEN_RE.finditer(source):
+        # Emit the literal text between the previous token and this one
+        result.append(source[prev_end : m.start()])
+        prev_end = m.end()
+
+        kind = m.lastgroup
+        raw = m.group()
+
+        if kind == "line":
+            result.append(_process_line_comment(raw))
+        elif kind == "block":
+            result.append(_process_block_comment(raw))
+        else:
+            # string, rawstring – emit verbatim
+            result.append(raw)
+
+    # Tail after the last token
+    result.append(source[prev_end:])
+    return "".join(result)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: capitalize_comments.py <file> [file ...]", file=sys.stderr)
+        return 1
+
+    changed_files = []
+    errors = []
+
+    for path in sys.argv[1:]:
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                original = fh.read()
+        except OSError as exc:
+            errors.append(f"Cannot read {path}: {exc}")
+            continue
+
+        processed = process_source(original)
+
+        if processed != original:
+            try:
+                with open(path, "w", encoding="utf-8") as fh:
+                    fh.write(processed)
+                changed_files.append(path)
+            except OSError as exc:
+                errors.append(f"Cannot write {path}: {exc}")
+
+    if changed_files:
+        print("capitalize_comments: capitalised comments in:")
+        for f in changed_files:
+            print(f"  {f}")
+
+    if errors:
+        for e in errors:
+            print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pre-commit/capitalize_md_comments.py
+++ b/pre-commit/capitalize_md_comments.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""
+capitalize_markdown_comments.py
+
+Pre-commit hook that capitalizes the first letter of HTML comments embedded
+in Markdown files. These are the only "comment" syntax available in Markdown.
+
+Handles:
+  - Single-line HTML comments  : <!-- some text -->  ->  <!-- Some text -->
+  - Multi-line HTML comments   : the first alphabetic character in the block
+                                  is capitalised; subsequent lines are untouched.
+
+Inline code spans, fenced code blocks, and link/image URLs are NOT modified.
+
+Usage (called by pre-commit):
+    python capitalize_markdown_comments.py <file1> [file2 ...]
+"""
+
+import re
+import sys
+
+
+# ---------------------------------------------------------------------------
+# Tokeniser
+# ---------------------------------------------------------------------------
+
+_TOKEN_RE = re.compile(
+    r"""
+    # --- fenced code block (``` or ~~~, skip entirely) ---
+    (?P<fence>
+        ^[ \t]*(?P<fence_char>`{3,}|~{3,})[^\n]*\n   # opening fence line
+        .*?                                             # content
+        ^[ \t]*(?P=fence_char)[^\n]*$                  # closing fence
+    )
+    |
+    # --- indented code block (4-space or tab indent) ---
+    (?P<indented>
+        (?:^(?:    |\t)[^\n]*\n)+
+    )
+    |
+    # --- inline code span ---
+    (?P<inline>`+[^`\n]+?`+)
+    |
+    # --- HTML comment <!-- ... --> ---
+    (?P<comment><!--.*?-->)
+    """,
+    re.VERBOSE | re.DOTALL | re.MULTILINE,
+)
+
+
+def _capitalize_comment_text(text: str) -> str:
+    """Uppercase the very first alphabetic character in *text*."""
+    stripped = text.lstrip(" \t")
+    if not stripped:
+        return text
+    # If the first non-whitespace character is not alphabetic (e.g. '<', '.',
+    # '(', '-', '1'), do not attempt capitalization.
+    if not stripped[0].isalpha():
+        return text
+
+    m = re.search(r"[a-zA-Z_]\w*", text)
+    if m:
+        if "_" in m.group(0):
+            return text
+        if m.group(0).lower() == "ros":
+            return text[: m.start()] + "ROS" + text[m.end() :]
+
+    for i, ch in enumerate(text):
+        if ch.isalpha():
+            return text[:i] + ch.upper() + text[i + 1 :]
+    return text
+
+
+def _process_html_comment(raw: str) -> str:
+    """Capitalise text inside an <!-- ... --> comment."""
+    assert raw.startswith("<!--") and raw.endswith("-->")
+    inner = raw[4:-3]
+
+    lines = inner.split("\n")
+    result_lines = []
+    capitalized = False
+
+    for line in lines:
+        if not capitalized:
+            m = re.match(r"^([ \t\-]*)(.*?)(\s*)$", line, re.DOTALL)
+            if m:
+                lead, body, trail = m.group(1), m.group(2), m.group(3)
+                new_body = _capitalize_comment_text(body)
+                result_lines.append(lead + new_body + trail)
+                if any(c.isalpha() for c in body):
+                    capitalized = True
+            else:
+                result_lines.append(line)
+        else:
+            result_lines.append(line)
+
+    return "<!--" + "\n".join(result_lines) + "-->"
+
+
+def process_source(source: str) -> str:
+    """Return *source* with all HTML comments capitalised."""
+    result = []
+    prev_end = 0
+
+    for m in _TOKEN_RE.finditer(source):
+        gap = source[prev_end : m.start()]
+        result.append(gap)
+        prev_end = m.end()
+
+        kind = m.lastgroup
+        raw = m.group()
+
+        if kind == "comment":
+            result.append(_process_html_comment(raw))
+        else:
+            # Fence, indented, inline – emit verbatim
+            result.append(raw)
+
+    result.append(source[prev_end:])
+    return "".join(result)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: capitalize_markdown_comments.py <file> [file ...]", file=sys.stderr)
+        return 1
+
+    changed_files = []
+    errors = []
+
+    for path in sys.argv[1:]:
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                original = fh.read()
+        except OSError as exc:
+            errors.append(f"Cannot read {path}: {exc}")
+            continue
+
+        processed = process_source(original)
+
+        if processed != original:
+            try:
+                with open(path, "w", encoding="utf-8") as fh:
+                    fh.write(processed)
+                changed_files.append(path)
+            except OSError as exc:
+                errors.append(f"Cannot write {path}: {exc}")
+
+    if changed_files:
+        print("capitalize_comments: capitalised comments in:")
+        for f in changed_files:
+            print(f"  {f}")
+
+    if errors:
+        for e in errors:
+            print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pre-commit/capitalize_python_comments.py
+++ b/pre-commit/capitalize_python_comments.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+capitalize_python_comments.py
+
+Pre-commit hook that capitalizes the first letter of every Python comment.
+
+Handles:
+  - Single-line comments  : # some text  ->  # Some text
+  - Inline comments       : x = 1  # note  ->  x = 1  # Note
+  - Block strings used as docstrings / multi-line comments are NOT touched
+    (they are string literals, not comments).
+
+Usage (called by pre-commit):
+    python capitalize_python_comments.py <file1> [file2 ...]
+"""
+
+import re
+import sys
+
+
+# ---------------------------------------------------------------------------
+# Tokeniser
+# ---------------------------------------------------------------------------
+
+# Split source into alternating non-comment / comment chunks so we never
+# accidentally capitalise string literals that look like comments.
+
+_TOKEN_RE = re.compile(
+    r"""
+    # --- triple-quoted strings (must come before single-quoted) ---
+    (?P<triple>
+        \"\"\"(?:[^"\\]|\\.|"(?!""))*\"\"\"   # triple double-quoted
+      | \'\'\'(?:[^'\\]|\\.|'(?!''))*\'\'\'   # triple single-quoted
+    )
+    |
+    # --- single / double quoted string literals ---
+    (?P<string>
+        "(?:[^"\\]|\\.)*"
+      | '(?:[^'\\]|\\.)*'
+    )
+    |
+    # --- Python comment (# to end of line, NOT consuming the newline) ---
+    (?P<comment>\#[^\n]*)
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+def _capitalize_comment_text(text: str) -> str:
+    """Uppercase the very first alphabetic character in *text*."""
+    stripped = text.lstrip(" \t")
+    if not stripped:
+        return text
+    # If the first non-whitespace character is not alphabetic (e.g. '<', '.',
+    # '(', '-', '1'), do not attempt capitalization.
+    if not stripped[0].isalpha():
+        return text
+
+    # Do not capitalize if the first word contains an underscore
+    # (likely a variable name or commented-out code).
+    m = re.search(r"[a-zA-Z_]\w*", text)
+    if m:
+        if "_" in m.group(0):
+            return text
+        if m.group(0).lower() == "ros":
+            return text[: m.start()] + "ROS" + text[m.end() :]
+
+    for i, ch in enumerate(text):
+        if ch.isalpha():
+            return text[:i] + ch.upper() + text[i + 1 :]
+    return text
+
+
+def _process_comment(raw: str) -> str:
+    """Capitalise a # comment, preserving the # prefix and any leading spaces."""
+    prefix = "#"
+    rest = raw[len(prefix) :]
+    # Preserve leading whitespace after #
+    stripped = rest.lstrip(" \t")
+    leading = rest[: len(rest) - len(stripped)]
+
+    # Shebangs, type-ignore, noqa, pylint, mypy, fmt directives - leave alone.
+    lower = stripped.lower()
+    if stripped.startswith("!") or lower.startswith(("type:", "noqa", "pylint", "mypy:", "fmt:")):
+        return raw
+
+    return prefix + leading + _capitalize_comment_text(stripped)
+
+
+def process_source(source: str) -> str:
+    """Return *source* with all # comments capitalised."""
+    result = []
+    prev_end = 0
+    last_was_comment = False
+
+    for m in _TOKEN_RE.finditer(source):
+        gap = source[prev_end : m.start()]
+        result.append(gap)
+        prev_end = m.end()
+
+        kind = m.lastgroup
+        raw = m.group()
+
+        if kind == "comment":
+            is_continuation = False
+            if last_was_comment and (not gap or gap.isspace()):
+                if gap.count("\n") <= 1:
+                    is_continuation = True
+
+            # Section-header comments (# ---...) are never continuations;
+            # they always start a new block and should be capitalised.
+            comment_body = raw[1:].lstrip(" \t")
+            if comment_body.startswith("---"):
+                is_continuation = False
+
+            if is_continuation:
+                result.append(raw)
+            else:
+                result.append(_process_comment(raw))
+            last_was_comment = True
+        else:
+            # Triple, string – emit verbatim
+            result.append(raw)
+            last_was_comment = False
+
+    result.append(source[prev_end:])
+    return "".join(result)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: capitalize_python_comments.py <file> [file ...]", file=sys.stderr)
+        return 1
+
+    changed_files = []
+    errors = []
+
+    for path in sys.argv[1:]:
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                original = fh.read()
+        except OSError as exc:
+            errors.append(f"Cannot read {path}: {exc}")
+            continue
+
+        processed = process_source(original)
+
+        if processed != original:
+            try:
+                with open(path, "w", encoding="utf-8") as fh:
+                    fh.write(processed)
+                changed_files.append(path)
+            except OSError as exc:
+                errors.append(f"Cannot write {path}: {exc}")
+
+    if changed_files:
+        print("capitalize_comments: capitalised comments in:")
+        for f in changed_files:
+            print(f"  {f}")
+
+    if errors:
+        for e in errors:
+            print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pre-commit/capitalize_txt_comments.py
+++ b/pre-commit/capitalize_txt_comments.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+capitalize_txt_comments.py
+
+Pre-commit hook that capitalizes the first letter of every line in plain
+text (.txt) files, treating each non-empty line as a "comment" / sentence
+that should start with a capital letter.
+
+Rules:
+  - Empty or whitespace-only lines are left untouched.
+  - Lines that start with a special marker (e.g. URLs, list bullets, numbers)
+    are left untouched.
+  - The first alphabetic character on each qualifying line is uppercased.
+
+Usage (called by pre-commit):
+    python capitalize_txt_comments.py <file1> [file2 ...]
+"""
+
+import re
+import sys
+
+
+# Patterns that indicate a line should NOT be auto-capitalized:
+#   - Lines starting with a URL scheme
+#   - Lines that are purely numeric / bullet / list markers
+#   - Lines with leading underscores (variable-like tokens)
+_SKIP_RE = re.compile(
+    r"""
+    ^[\s]*           # optional leading whitespace
+    (?:
+        https?://    # URL
+      | \d+\.        # ordered list  "1. item"
+      | [-*+]\s      # unordered bullet
+      | \[           # markdown-style checkbox / link
+      | [A-Z_]{2,}   # ALL_CAPS constant or header
+    )
+    """,
+    re.VERBOSE,
+)
+
+
+def _capitalize_line(line: str) -> str:
+    """Capitalize the first alphabetic character on the line."""
+    stripped = line.lstrip(" \t")
+    if not stripped:
+        return line
+    # If the first non-whitespace character is not alphabetic (e.g. '<', '.',
+    # '(', '-', '1'), do not attempt capitalization.
+    if not stripped[0].isalpha():
+        return line
+
+    # Check for leading word with underscore (variable name / code), function calls, or paths
+    m = re.search(r"([a-zA-Z_]\w*)([/\(]?)", line)
+    if m:
+        if "_" in m.group(1) or m.group(2):
+            return line
+
+    # First non-whitespace character is alphabetic, so capitalize that one.
+    idx = len(line) - len(stripped)
+    return line[:idx] + stripped[0].upper() + stripped[1:]
+
+
+def process_source(source: str) -> str:
+    """Return *source* with the first letter of each line capitalised."""
+    lines = source.splitlines(keepends=True)
+    result = []
+    last_was_processed = False
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            result.append(line)
+            last_was_processed = False
+            continue
+
+        if _SKIP_RE.match(line):
+            result.append(line)
+            last_was_processed = False
+            continue
+
+        # Continuation lines: if the previous line was processed and this
+        # line does not look like the start of a new sentence (no leading
+        # whitespace reset, line doesn't end a sentence) - leave it.
+        # For plain text we apply capitalization only to the first line of
+        # each "block" (paragraph).  A blank line separates blocks.
+        if last_was_processed:
+            result.append(line)
+        else:
+            result.append(_capitalize_line(line))
+            last_was_processed = True
+
+    return "".join(result)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: capitalize_txt_comments.py <file> [file ...]", file=sys.stderr)
+        return 1
+
+    changed_files = []
+    errors = []
+
+    for path in sys.argv[1:]:
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                original = fh.read()
+        except OSError as exc:
+            errors.append(f"Cannot read {path}: {exc}")
+            continue
+
+        processed = process_source(original)
+
+        if processed != original:
+            try:
+                with open(path, "w", encoding="utf-8") as fh:
+                    fh.write(processed)
+                changed_files.append(path)
+            except OSError as exc:
+                errors.append(f"Cannot write {path}: {exc}")
+
+    if changed_files:
+        print("capitalize_comments: capitalised first lines of blocks in:")
+        for f in changed_files:
+            print(f"  {f}")
+
+    if errors:
+        for e in errors:
+            print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pre-commit/capitalize_txt_comments.py
+++ b/pre-commit/capitalize_txt_comments.py
@@ -1,16 +1,27 @@
 #!/usr/bin/env python3
-"""
-capitalize_txt_comments.py
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026, DRAGON Laboratory, The University of Tokyo
 
-Pre-commit hook that capitalizes the first letter of every line in plain
-text (.txt) files, treating each non-empty line as a "comment" / sentence
-that should start with a capital letter.
+"""capitalize_txt_comments.py
 
-Rules:
-  - Empty or whitespace-only lines are left untouched.
-  - Lines that start with a special marker (e.g. URLs, list bullets, numbers)
-    are left untouched.
-  - The first alphabetic character on each qualifying line is uppercased.
+Pre-commit hook that capitalizes comment lines in *CMakeLists.txt* only.
+
+This repository includes a number of hooks that operate on "*.txt"-suffixed
+files. However, "CMakeLists.txt" is a special case: it ends with ".txt" but is
+not a plain text document. This hook exists purely to format *CMakeLists.txt*
+comment lines without ever touching CMake code.
+
+Behavior:
+    - Only files whose basename is exactly "CMakeLists.txt" are processed.
+    - All other files (including other ".txt" files) are ignored completely.
+
+Rules (CMakeLists.txt mode):
+    - Only full-line comments (start with "#" after optional whitespace).
+        - Only comments with whitespace after the leading "#" (or "###") are
+            eligible (e.g. "# foo"); lines like "#foo" are treated as commented-out
+            code / directives and left untouched.
+    - Commented-out code / identifiers (e.g. containing "_", "::", "(") are left
+      untouched to avoid breaking builds.
 
 Usage (called by pre-commit):
     python capitalize_txt_comments.py <file1> [file2 ...]
@@ -18,6 +29,8 @@ Usage (called by pre-commit):
 
 import re
 import sys
+from pathlib import Path
+from typing import Optional
 
 
 # Patterns that indicate a line should NOT be auto-capitalized:
@@ -37,6 +50,55 @@ _SKIP_RE = re.compile(
     """,
     re.VERBOSE,
 )
+
+
+_SKIP_COMMENT_TEXT_RE = re.compile(
+    r"""
+    ^(?:
+        https?://    # URL
+      | \d+\.        # ordered list  "1. item"
+      | [-*+]\s      # unordered bullet
+      | \[           # markdown-style checkbox / link
+      | [A-Z_]{2,}   # ALL_CAPS constant or header
+    )
+    """,
+    re.VERBOSE,
+)
+
+
+def _is_target_file(path: str) -> bool:
+    """Return True if *path* should be processed by this hook."""
+    return Path(path).name == "CMakeLists.txt"
+
+
+def _capitalize_first_alpha(text: str) -> str:
+    """Capitalize the first alphabetic character in *text* (preserving prefix).
+
+    This is intentionally more general than "capitalize first non-whitespace".
+    For separator-style comments like "--- header ---", we still want to
+    capitalise the first *alphabetic* character ("--- Header ---").
+    """
+
+    for i, ch in enumerate(text):
+        if ch.isalpha():
+            return text[:i] + ch.upper() + text[i + 1 :]
+    return text
+
+
+def _looks_like_code_or_identifier(text: str) -> bool:
+    """Heuristic: avoid touching commented-out code / targets / identifiers."""
+    stripped = text.lstrip(" \t")
+    if not stripped:
+        return False
+    if stripped.startswith("${"):
+        return True
+    if "::" in stripped or "(" in stripped or ")" in stripped:
+        return True
+    m = re.match(r"([A-Za-z_][\w:]*)", stripped)
+    if not m:
+        return False
+    token = m.group(1)
+    return "_" in token
 
 
 def _capitalize_line(line: str) -> str:
@@ -60,36 +122,62 @@ def _capitalize_line(line: str) -> str:
     return line[:idx] + stripped[0].upper() + stripped[1:]
 
 
-def process_source(source: str) -> str:
-    """Return *source* with the first letter of each line capitalised."""
+def process_cmake_source(source: str) -> str:
+    """Return *source* with eligible CMake comment lines capitalised.
+
+    Only lines that start with '#' after optional whitespace are considered.
+    """
     lines = source.splitlines(keepends=True)
-    result = []
-    last_was_processed = False
+    result: list[str] = []
 
     for line in lines:
-        stripped = line.strip()
-        if not stripped:
+        # Preserve blank/whitespace-only lines
+        if not line.strip():
             result.append(line)
-            last_was_processed = False
             continue
 
-        if _SKIP_RE.match(line):
+        m = re.match(r"^(\s*#+)(\s*)(.*?)(\r?\n)?$", line)
+        if not m:
             result.append(line)
-            last_was_processed = False
             continue
 
-        # Continuation lines: if the previous line was processed and this
-        # line does not look like the start of a new sentence (no leading
-        # whitespace reset, line doesn't end a sentence) - leave it.
-        # For plain text we apply capitalization only to the first line of
-        # each "block" (paragraph).  A blank line separates blocks.
-        if last_was_processed:
+        hashes, spaces, comment_text, newline = m.groups()
+        newline = newline or ""
+
+        # Treat lines like "#add_library(...)" (no whitespace after '#') as
+        # commented-out code / directives and do not touch them.
+        if spaces == "":
             result.append(line)
-        else:
-            result.append(_capitalize_line(line))
-            last_was_processed = True
+            continue
+
+        comment_stripped = comment_text.lstrip(" \t")
+        if not comment_stripped:
+            result.append(line)
+            continue
+
+        if _SKIP_COMMENT_TEXT_RE.match(comment_stripped):
+            result.append(line)
+            continue
+
+        if _looks_like_code_or_identifier(comment_text):
+            result.append(line)
+            continue
+
+        updated_comment = _capitalize_first_alpha(comment_text)
+        result.append(f"{hashes}{spaces}{updated_comment}{newline}")
 
     return "".join(result)
+
+
+def process_source(source: str, *, file_path: Optional[str] = None) -> str:
+    """Return processed *source*.
+
+    Only *CMakeLists.txt* is modified. All other files are returned unchanged.
+    """
+    if not (file_path and _is_target_file(file_path)):
+        return source
+
+    return process_cmake_source(source)
 
 
 # ---------------------------------------------------------------------------
@@ -106,6 +194,9 @@ def main() -> int:
     errors = []
 
     for path in sys.argv[1:]:
+        if not _is_target_file(path):
+            continue
+
         try:
             with open(path, "r", encoding="utf-8") as fh:
                 original = fh.read()
@@ -113,7 +204,7 @@ def main() -> int:
             errors.append(f"Cannot read {path}: {exc}")
             continue
 
-        processed = process_source(original)
+        processed = process_source(original, file_path=path)
 
         if processed != original:
             try:

--- a/pre-commit/capitalize_xml_comments.py
+++ b/pre-commit/capitalize_xml_comments.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+capitalize_xml_comments.py
+
+Pre-commit hook that capitalizes the first letter of every XML/Xacro comment.
+
+Handles:
+  - Single-line XML comments  : <!-- some text -->  ->  <!-- Some text -->
+  - Multi-line XML comments   : the first alphabetic character in the block
+                                 is capitalised; subsequent lines are untouched.
+
+XML CDATA sections, attribute values, and element text content are NOT modified.
+
+Works for both .xml and .xacro files.
+
+Usage (called by pre-commit):
+    python capitalize_xml_comments.py <file1> [file2 ...]
+"""
+
+import re
+import sys
+
+
+# ---------------------------------------------------------------------------
+# Tokeniser
+# ---------------------------------------------------------------------------
+
+_TOKEN_RE = re.compile(
+    r"""
+    # --- CDATA section (skip entirely) ---
+    (?P<cdata><!\[CDATA\[.*?\]\]>)
+    |
+    # --- XML comment <!-- ... --> ---
+    (?P<comment><!--.*?-->)
+    |
+    # --- quoted attribute value (skip) ---
+    (?P<dquote>"[^"]*")
+    |
+    (?P<squote>'[^']*')
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+def _capitalize_comment_text(text: str) -> str:
+    """Uppercase the very first alphabetic character in *text*."""
+    stripped = text.lstrip(" \t")
+    if not stripped:
+        return text
+    # If the first non-whitespace character is not alphabetic (e.g. '<', '.',
+    # '(', '-', '1'), do not attempt capitalization.
+    if not stripped[0].isalpha():
+        return text
+
+    m = re.search(r"[a-zA-Z_]\w*", text)
+    if m:
+        if "_" in m.group(0):
+            return text
+        if m.group(0).lower() == "ros":
+            return text[: m.start()] + "ROS" + text[m.end() :]
+
+    for i, ch in enumerate(text):
+        if ch.isalpha():
+            return text[:i] + ch.upper() + text[i + 1 :]
+    return text
+
+
+def _process_xml_comment(raw: str) -> str:
+    """Capitalise text inside an <!-- ... --> comment."""
+    assert raw.startswith("<!--") and raw.endswith("-->")
+    inner = raw[4:-3]  # Everything between <!-- and -->
+
+    lines = inner.split("\n")
+    result_lines = []
+    capitalized = False
+
+    for line in lines:
+        if not capitalized:
+            # Strip decorative leading dashes or spaces
+            m = re.match(r"^([ \t\-]*)(.*?)(\s*)$", line, re.DOTALL)
+            if m:
+                lead, body, trail = m.group(1), m.group(2), m.group(3)
+                new_body = _capitalize_comment_text(body)
+                result_lines.append(lead + new_body + trail)
+                if any(c.isalpha() for c in body):
+                    capitalized = True
+            else:
+                result_lines.append(line)
+        else:
+            result_lines.append(line)
+
+    return "<!--" + "\n".join(result_lines) + "-->"
+
+
+def process_source(source: str) -> str:
+    """Return *source* with all XML comments capitalised."""
+    result = []
+    prev_end = 0
+
+    for m in _TOKEN_RE.finditer(source):
+        gap = source[prev_end : m.start()]
+        result.append(gap)
+        prev_end = m.end()
+
+        kind = m.lastgroup
+        raw = m.group()
+
+        if kind == "comment":
+            result.append(_process_xml_comment(raw))
+        else:
+            # Cdata, dquote, squote – emit verbatim
+            result.append(raw)
+
+    result.append(source[prev_end:])
+    return "".join(result)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: capitalize_xml_comments.py <file> [file ...]", file=sys.stderr)
+        return 1
+
+    changed_files = []
+    errors = []
+
+    for path in sys.argv[1:]:
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                original = fh.read()
+        except OSError as exc:
+            errors.append(f"Cannot read {path}: {exc}")
+            continue
+
+        processed = process_source(original)
+
+        if processed != original:
+            try:
+                with open(path, "w", encoding="utf-8") as fh:
+                    fh.write(processed)
+                changed_files.append(path)
+            except OSError as exc:
+                errors.append(f"Cannot write {path}: {exc}")
+
+    if changed_files:
+        print("capitalize_comments: capitalised comments in:")
+        for f in changed_files:
+            print(f"  {f}")
+
+    if errors:
+        for e in errors:
+            print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pre-commit/capitalize_yaml_comments.py
+++ b/pre-commit/capitalize_yaml_comments.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""
+capitalize_yaml_comments.py
+
+Pre-commit hook that capitalizes the first letter of every YAML comment.
+
+Handles:
+  - Full-line comments  : # some text  ->  # Some text
+  - Inline comments     : key: value  # note  ->  key: value  # Note
+
+YAML string values (quoted or block scalars) are never modified.
+
+Usage (called by pre-commit):
+    python capitalize_yaml_comments.py <file1> [file2 ...]
+"""
+
+import re
+import sys
+
+
+# ---------------------------------------------------------------------------
+# Tokeniser
+# ---------------------------------------------------------------------------
+
+# We tokenise enough YAML syntax to skip over string literals safely.
+# YAML is complex; we cover the common cases: double-quoted, single-quoted,
+# and block/flow scalars are skipped by not matching them as comments.
+
+_TOKEN_RE = re.compile(
+    r"""
+    # --- double-quoted YAML string ---
+    (?P<dquote>"(?:[^"\\]|\\.)*")
+    |
+    # --- single-quoted YAML string ('' is an escaped single quote) ---
+    (?P<squote>'(?:[^']|'')*')
+    |
+    # --- YAML comment (# to end of line, NOT consuming the newline) ---
+    # Only match # that is preceded by start-of-line or whitespace, to avoid
+    # matching # inside unquoted values like anchor names (&foo).
+    (?P<comment>(?:^|(?<=\s))\#[^\n]*)
+    """,
+    re.VERBOSE | re.MULTILINE,
+)
+
+
+def _capitalize_comment_text(text: str) -> str:
+    """Uppercase the very first alphabetic character in *text*."""
+    stripped = text.lstrip(" \t")
+    if not stripped:
+        return text
+    # If the first non-whitespace character is not alphabetic (e.g. '<', '.',
+    # '(', '-', '1'), do not attempt capitalization.
+    if not stripped[0].isalpha():
+        return text
+
+    m = re.search(r"[a-zA-Z_]\w*", text)
+    if m:
+        if "_" in m.group(0):
+            return text
+        if m.group(0).lower() == "ros":
+            return text[: m.start()] + "ROS" + text[m.end() :]
+
+    for i, ch in enumerate(text):
+        if ch.isalpha():
+            return text[:i] + ch.upper() + text[i + 1 :]
+    return text
+
+
+def _process_comment(raw: str) -> str:
+    """Capitalise a # comment, preserving the # prefix and any leading spaces."""
+    # Raw may start with whitespace captured by the lookbehind workaround -
+    # find the actual '#' character.
+    hash_idx = raw.index("#")
+    before_hash = raw[:hash_idx]  # Any captured leading whitespace (empty or space)
+    rest = raw[hash_idx + 1 :]  # Everything after '#'
+
+    stripped = rest.lstrip(" \t")
+    leading = rest[: len(rest) - len(stripped)]
+
+    # Special directives - leave alone.
+    lower = stripped.lower()
+    if lower.startswith(("noqa", "type:", "fmt:", "yaml-language-server")):
+        return raw
+
+    return before_hash + "#" + leading + _capitalize_comment_text(stripped)
+
+
+def process_source(source: str) -> str:
+    """Return *source* with all # comments capitalised."""
+    result = []
+    prev_end = 0
+    last_was_comment = False
+
+    for m in _TOKEN_RE.finditer(source):
+        gap = source[prev_end : m.start()]
+        result.append(gap)
+        prev_end = m.end()
+
+        kind = m.lastgroup
+        raw = m.group()
+
+        if kind == "comment":
+            is_continuation = False
+            if last_was_comment and (not gap or gap.isspace()):
+                if gap.count("\n") <= 1:
+                    is_continuation = True
+
+            if is_continuation:
+                result.append(raw)
+            else:
+                result.append(_process_comment(raw))
+            last_was_comment = True
+        else:
+            result.append(raw)
+            last_was_comment = False
+
+    result.append(source[prev_end:])
+    return "".join(result)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: capitalize_yaml_comments.py <file> [file ...]", file=sys.stderr)
+        return 1
+
+    changed_files = []
+    errors = []
+
+    for path in sys.argv[1:]:
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                original = fh.read()
+        except OSError as exc:
+            errors.append(f"Cannot read {path}: {exc}")
+            continue
+
+        processed = process_source(original)
+
+        if processed != original:
+            try:
+                with open(path, "w", encoding="utf-8") as fh:
+                    fh.write(processed)
+                changed_files.append(path)
+            except OSError as exc:
+                errors.append(f"Cannot write {path}: {exc}")
+
+    if changed_files:
+        print("capitalize_comments: capitalised comments in:")
+        for f in changed_files:
+            print(f"  {f}")
+
+    if errors:
+        for e in errors:
+            print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robots/hydrus/config/quad/default_mode_201907/Servo.yaml
+++ b/robots/hydrus/config/quad/default_mode_201907/Servo.yaml
@@ -1,7 +1,6 @@
 /**/servo_bridge:
   ros__parameters:
     servo_controller:
-
       groups:
         - joints
 
@@ -25,7 +24,7 @@
         simulation:
           type: joint_group_position_controller
 
-# joints setting for simulation
+# Joints setting for simulation
 /**/joint_group_position_controller:
   ros__parameters:
     joints:

--- a/robots/hydrus/launch/bringup_launch.py
+++ b/robots/hydrus/launch/bringup_launch.py
@@ -1,284 +1,245 @@
 #!/usr/bin/env python3
-import os
-
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, RegisterEventHandler
-from launch.event_handlers import OnExecutionComplete
-from launch.conditions import IfCondition, UnlessCondition
-from launch.substitutions import (
-    LaunchConfiguration,
-    Command,
-    PathJoinSubstitution,
-    TextSubstitution,
-    FindExecutable,
-    PythonExpression
-)
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, PythonExpression, TextSubstitution, Command, FindExecutable
+from launch.conditions import IfCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
-from launch_ros.parameter_descriptions import ParameterValue, ParameterFile
-from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import PathJoinSubstitution
+from launch_ros.parameter_descriptions import ParameterValue
+
+
+# ---------------------------------------------------------------------------
+# Argument declarations  (name, default, description, (optional) choices)
+# ---------------------------------------------------------------------------
+_ARGS = [
+    ("robot_model",         "hydrus",              "Name of the robot model ROS package"),
+    ("robot_ns",            "hydrus",              "Namespace for all robot nodes"),
+    ("real_machine",        "true",                "Use real machine specific bring-up inside model_launch", ["true", "false"]),
+    ("main_rate",           "40.0",                "Core node main loop rate [Hz]"),
+    ("estimation_mode",     "0",                   "Estimator mode on real machine: 0=egomotion, 1=experiment, 2=ground-truth", ["0", "1", "2"]),
+    ("onboards_model",      "default_mode_201907", "On-board hardware model configuration subdirectory"),
+    ("model_options",       "",                    "Extra xacro arguments passed verbatim to xacro"),
+    ("headless",            "true",                "Run without GUI", ["true", "false"]),
+    ("sim",                 "false",               "Launch Gazebo simulation", ["true", "false"]),
+    ("sim_estimation_mode", "2",                   "Estimator mode in simulation: 0=egomotion, 1=experiment, 2=ground-truth", ["0", "1", "2"]),
+    ("spawn_x",             "0.0",                 "Gazebo spawn X position [m] (sim only)"),
+    ("spawn_y",             "0.0",                 "Gazebo spawn Y position [m] (sim only)"),
+    ("spawn_z",             "0.5",                 "Gazebo spawn Z position [m] (sim only)"),
+    ("robot_model_rviz",    "rviz_config.rviz",    "RViz config filename (resolved inside robot_model pkg/config/)"),
+]
+
+def sanity_check(context, *args, **kwargs):
+    # Evaulate AFTER substitutions (e.g., sim and estimation_mode) are resolved, but BEFORE any nodes are launched
+    # NOTE: Together with "choices" only real possibility to guardrail arguments
+    real_machine = LaunchConfiguration("real_machine").perform(context)
+    sim = LaunchConfiguration("sim").perform(context)
+    if real_machine.lower() == "true" and sim.lower() == "true":
+        raise RuntimeError("real_machine and sim arguments cannot both be true")
+
+    rate = float(LaunchConfiguration("main_rate").perform(context))
+    if rate <= 0 or rate > 200:
+        raise RuntimeError(f"main_rate={rate} is not as expected. ")
+
 
 def generate_launch_description():
+    # ------------------------------------------------------------------
+    # 1.  Declare CLI-overridable arguments
+    # ------------------------------------------------------------------
+    declared_args = [
+        DeclareLaunchArgument(
+            name,
+            default_value=default_value,
+            description=description,
+            **({"choices": choices[0]} if choices else {})
+        )
+        for name, default_value, description, *choices in _ARGS
+    ]
 
-    # --- LaunchConfiguration ---
-    headless         = LaunchConfiguration('headless')
-    model_options    = LaunchConfiguration('model_options')
-    robot_model_pkg  = LaunchConfiguration('robot_model')
-    robot_ns         = LaunchConfiguration('robot_ns')
-    robot_model_rviz = LaunchConfiguration('robot_model_rviz')
-    onboards_model   = LaunchConfiguration('onboards_model')
-    estimate_mode    = LaunchConfiguration('estimate_mode')
-    sim_estimate_mode= LaunchConfiguration('sim_estimate_mode')
-    sim       = LaunchConfiguration('sim')
-    rm       = LaunchConfiguration('rm')
-    spawn_x = LaunchConfiguration('spawn_x')
-    spawn_y = LaunchConfiguration('spawn_y')
-    spawn_z = LaunchConfiguration('spawn_z')
+    # Resolve / Read at launch time (NOT AT IMPORT TIME)
+    robot_model_pkg     = LaunchConfiguration("robot_model")
+    robot_ns            = LaunchConfiguration("robot_ns")
+    real_machine        = LaunchConfiguration("real_machine")
+    main_rate           = LaunchConfiguration("main_rate")
+    estimation_mode     = LaunchConfiguration("estimation_mode")
+    onboards_model      = LaunchConfiguration("onboards_model")
+    model_options       = LaunchConfiguration("model_options")
+    headless            = LaunchConfiguration("headless")
+    sim                 = LaunchConfiguration("sim")
+    sim_estimation_mode = LaunchConfiguration("sim_estimation_mode")
+    spawn_x             = LaunchConfiguration("spawn_x")
+    spawn_y             = LaunchConfiguration("spawn_y")
+    spawn_z             = LaunchConfiguration("spawn_z")
+    robot_model_rviz    = LaunchConfiguration("robot_model_rviz")
 
-    # --- DeclareLaunchArgument ---
-    headless_arg = DeclareLaunchArgument(
-        'headless',
-        default_value='False',
-        description='Run without GUI (headless mode)'
-    )
+    # TODO: get plugin name from yaml file
+    robot_model_plugin_name = {
+        "robot_model_plugin_name": ParameterValue(
+            "multirotor_robot_model",
+            value_type=str
+        )
+    }
 
-    model_options_arg = DeclareLaunchArgument(
-        'model_options',
-        default_value='',
-        description='Additional model options (e.g., extra URDF args)'
-    )
+    active_estimation_mode = PythonExpression([
+        "int('", sim_estimation_mode, "') if '", sim, "' == 'true' else int('", estimation_mode, "')"
+    ])
 
-    robot_model_pkg_arg = DeclareLaunchArgument(
-        'robot_model',
-        default_value='hydrus',
-        description='Name of the robot model package'
-    )
+    # ------------------------------------------------------------------
+    # 2.  Derived paths
+    # ------------------------------------------------------------------    
+    state_estimation_path = PathJoinSubstitution([
+        FindPackageShare(robot_model_pkg),
+        "config", "quad", onboards_model, "StateEstimation.yaml",
+    ])
+    
+    servo_param_path = PathJoinSubstitution([
+        FindPackageShare(robot_model_pkg),
+        "config", "quad", onboards_model, "Servo.yaml",
+    ])
 
-    robot_ns_arg = DeclareLaunchArgument(
-        'robot_ns',
-        default_value='hydrus',
-        description='ROS namespace under which to launch the robot'
-    )
-
-    robot_model_rviz_arg = DeclareLaunchArgument(
-        'robot_model_rviz',
-        default_value='rviz_config.rviz',
-        description='RViz display configuration for the robot model'
-    )
-
-    onboards_model_arg = DeclareLaunchArgument(
-        'onboards_model',
-        default_value='default_mode_201907',
-        description='On-board hardware model configuration'
-    )
-
-    estimate_mode_arg = DeclareLaunchArgument(
-        'estimate_mode',
-        default_value='0',
-        description='Estimate mode (e.g., 0 for egomotion mode; 1 for experiment mode; 2 for ground truth mode)'
-    )
-
-    sim_estimate_mode_arg = DeclareLaunchArgument(
-        'sim_estimate_mode',
-        default_value='2',
-        description='Estimate mode in Simulation (e.g., 0 for egomotion mode; 1 for experiment mode; 2 for ground truth mode)'
-    )
-
-    simulation_arg = DeclareLaunchArgument(
-        'sim',
-        default_value='false',
-        description='Run in simulation mode (e.g., use Gazebo clock)'
-    )
-
-    realmachine_arg = DeclareLaunchArgument(
-        'rm',
-        default_value='false',
-        description='Run in realmachine mode'
-    )
-
-    spawn_x_arg = DeclareLaunchArgument(
-        'spawn_x',
-        default_value='0.0',
-        description='Initial X position'
-    )
-    spawn_y_arg = DeclareLaunchArgument(
-        'spawn_y',
-        default_value='0.0',
-        description='Initial Y position'
-    )
-    spawn_z_arg = DeclareLaunchArgument(
-        'spawn_z',
-        default_value='0.5',
-        description='Initial Z position'
-    )    
-
-    # --- robot_description parameter  ---
-    xacro_type = PythonExpression([
+    xacro_filename = PythonExpression([
         "'robot.gazebo.xacro' if '", sim, "' == 'true' else 'robot.urdf.xacro'"
     ])
-    
-    urdf_xacro = PathJoinSubstitution([
+
+    xacro_path = PathJoinSubstitution([
+        # TODO: remove redundant and imprecise "quad" directory level (also in config/)
         FindPackageShare(robot_model_pkg),
-        'robots',
-        'quad',
-        onboards_model,
-        xacro_type
+        "robots", "quad", onboards_model, xacro_filename,
     ])
 
-    robot_description_content = Command([
-        'xacro ',
-        urdf_xacro,
-        model_options
-    ])
-    
-    robot_description = {
-        'robot_description':
-        ParameterValue(
-            robot_description_content,
+    # Build the URDF/xacro string via the xacro CLI.
+    # model_options is appended verbatim so callers can inject extra xacro args, e.g.,:
+    #   model_options:="prop_num:=6 payload:=true"
+    robot_description = [
+        FindExecutable(name="xacro"),
+        TextSubstitution(text=" "),
+        xacro_path,
+        TextSubstitution(text=" "),
+        model_options,
+    ]
+    robot_description_param = {
+        "robot_description": ParameterValue(
+            Command(robot_description),
             value_type=str
         )
     }
 
-    # --- servo parameter  ---
-    servo_param_file = PathJoinSubstitution([
+    sim_param_path = PathJoinSubstitution([
         FindPackageShare(robot_model_pkg),
-        'config',
-        'quad',
-        onboards_model,
-        'Servo.yaml',
+        "config", "Simulation.yaml",
     ])
 
-    # --- simulation parameter  ---
-    sim_param_file = PathJoinSubstitution([
+    # TODO: Use or remove
+    rviz_config_path = PathJoinSubstitution([
         FindPackageShare(robot_model_pkg),
-        'config',
-        'Simulation.yaml',
-    ])    
-
-    # --- robot model parameter  TODO: get from yaml file---
-    robot_model_plugin_name = {
-        'robot_model_plugin_name':
-        ParameterValue(
-            'multirotor_robot_model',
-            value_type=str
-        )
-    }
-
-    # --- state estimation parameter  ---
-    state_estimation_file = PathJoinSubstitution([
-        FindPackageShare(robot_model_pkg),
-        'config',
-        'quad',
-        onboards_model,
-        'StateEstimation.yaml',
+        "config", robot_model_rviz
     ])
 
-    # --- rviz config path ---w
-    rviz_config = PathJoinSubstitution([
-        FindPackageShare(robot_model_pkg),
-        'config',
-        robot_model_rviz
-    ])
-    
-    # --- nodes ---
-    core_node =  Node(
-        package='aerial_robot_core',
-        executable='aerial_robot_core_node',
-        name='aerial_robot_core',
+    # ------------------------------------------------------------------
+    # 3.  Nodes
+    # ------------------------------------------------------------------
+    core_node = Node(
+        package="aerial_robot_core",
+        executable="aerial_robot_core_node",
+        name="aerial_robot_core",
         namespace=robot_ns,
-        parameters=[{'use_sim_time': sim,
-                     'main_rate': 40.0,
-                     'estimation.mode': PythonExpression([
-                         sim_estimate_mode, " if '", sim, "' == 'true' else '", estimate_mode, "'"])},
-                    robot_description,
-                    robot_model_plugin_name,
-                    state_estimation_file],
-        output = 'screen'
+        parameters=[
+            {
+                "main_rate": main_rate,
+                "estimation.mode": active_estimation_mode,
+                "use_sim_time": sim,
+            },
+            robot_description_param,
+            robot_model_plugin_name,
+            state_estimation_path,
+        ],
+        output="screen",
     )
 
     servo_bridge_node = Node(
-        package='aerial_robot_model',
-        executable='servo_bridge_node',
-        name='servo_bridge',
+        package="aerial_robot_model",
+        executable="servo_bridge_node",
+        name="servo_bridge",
         namespace=robot_ns,
-        parameters=[robot_description, servo_param_file,
-                    {
-                        'sim': sim,
-                    }
+        parameters=[
+            robot_description_param,
+            servo_param_path,
+            {
+                "sim": sim,
+            },
         ],
-    )
-
-    model_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            PathJoinSubstitution([
-                FindPackageShare('aerial_robot_model'),
-                'launch',
-                'aerial_robot_model_launch.py'
-            ])
-        ),
-        launch_arguments={
-            'headless': LaunchConfiguration('headless'),
-            'rm': LaunchConfiguration('rm'),
-            'sim': LaunchConfiguration('sim'),
-            'model_options': LaunchConfiguration('model_options'),
-            'robot_model': LaunchConfiguration('robot_model'),
-            'robot_ns': LaunchConfiguration('robot_ns'),
-            'robot_model_rviz': LaunchConfiguration('robot_model_rviz'),
-            'robot_description_content': robot_description_content,
-        }.items(),
-    )
-    
-    sim_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            PathJoinSubstitution([
-                FindPackageShare('aerial_robot_simulation'),
-                'launch',
-                'gazebo_launch.py'
-            ])
-        ),
-        launch_arguments={
-            'robot_name': LaunchConfiguration('robot_ns'),
-            'spawn_x': LaunchConfiguration('spawn_x'),
-            'spawn_y': LaunchConfiguration('spawn_y'),
-            'spawn_z': LaunchConfiguration('spawn_z'),
-            'sim_param_file':   sim_param_file,
-            'headless': LaunchConfiguration('headless'),
-        }.items(),
-        condition=IfCondition(sim),
+        output="screen",
     )
 
     joint_position_spawner = Node(
-        namespace= robot_ns,
-        package='controller_manager',
-        executable='spawner',
-        name='spawn_joint_group_position_controller',
-        output='screen',
+        namespace=robot_ns,
+        package="controller_manager",
+        executable="spawner",
+        name="spawn_joint_group_position_controller",
         arguments=[
-            'joint_group_position_controller',
-            '--param-file', sim_param_file,
-            '--param-file', servo_param_file,
+            "joint_group_position_controller",
+            "--param-file", sim_param_path,
+            "--param-file", servo_param_path,
         ],
+        condition=IfCondition(sim),
+        output="screen",
+    )
+
+    # ------------------------------------------------------------------
+    # 4.  Call child launch files
+    # ------------------------------------------------------------------
+    # Robot model (URDF publisher, RViz, joint-state publisher …)
+    model_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution([
+                FindPackageShare("aerial_robot_model"),
+                "launch", "aerial_robot_model_launch.py",
+            ])
+        ),
+        launch_arguments={
+            "robot_model": robot_model_pkg,
+            "robot_ns": robot_ns,
+            "real_machine": real_machine,
+            "model_options": model_options,
+            "headless": headless,
+            "robot_model_rviz": robot_model_rviz,
+            "robot_description": robot_description,
+            "sim": sim,
+        }.items(),
+    )
+
+    # Gazebo simulation
+    sim_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution([
+                FindPackageShare("aerial_robot_simulation"),
+                "launch", "gazebo_launch.py",
+            ])
+        ),
+        launch_arguments={
+            "robot_ns": robot_ns,
+            "headless": headless,
+            "sim_param_path": sim_param_path,
+            "spawn_x": spawn_x,
+            "spawn_y": spawn_y,
+            "spawn_z": spawn_z,
+        }.items(),
         condition=IfCondition(sim),
     )
 
+    # ------------------------------------------------------------------
+    # 5.  Assemble LaunchDescription
+    # ------------------------------------------------------------------
     ld = LaunchDescription()
-    ld.add_action(headless_arg)
-    ld.add_action(model_options_arg)
-    ld.add_action(robot_model_pkg_arg)
-    ld.add_action(robot_ns_arg)
-    ld.add_action(robot_model_rviz_arg)
-    ld.add_action(onboards_model_arg)
-    ld.add_action(estimate_mode_arg)
-    ld.add_action(sim_estimate_mode_arg)
-    ld.add_action(simulation_arg)
-    ld.add_action(realmachine_arg)
-    ld.add_action(spawn_x_arg)
-    ld.add_action(spawn_y_arg)
-    ld.add_action(spawn_z_arg)
+
+    for arg in declared_args:
+        ld.add_action(arg)
+
+    ld.add_action(OpaqueFunction(function=sanity_check))
     ld.add_action(core_node)
     ld.add_action(servo_bridge_node)
+    ld.add_action(joint_position_spawner)
     ld.add_action(model_launch)
     ld.add_action(sim_launch)
-    ld.add_action(joint_position_spawner)
+
     return ld

--- a/robots/mini_quadrotor/launch/bringup_launch.py
+++ b/robots/mini_quadrotor/launch/bringup_launch.py
@@ -1,236 +1,214 @@
 #!/usr/bin/env python3
-import os
-
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, RegisterEventHandler
-from launch.event_handlers import OnExecutionComplete
-from launch.conditions import IfCondition, UnlessCondition
-from launch.substitutions import (
-    LaunchConfiguration,
-    Command,
-    PathJoinSubstitution,
-    TextSubstitution,
-    FindExecutable,
-    PythonExpression
-)
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, PythonExpression, TextSubstitution, Command, FindExecutable
+from launch.conditions import IfCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
-from launch_ros.parameter_descriptions import ParameterValue, ParameterFile
-from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import PathJoinSubstitution
+from launch_ros.parameter_descriptions import ParameterValue
+
+
+# ---------------------------------------------------------------------------
+# Argument declarations  (name, default, description, (optional) choices)
+# ---------------------------------------------------------------------------
+_ARGS = [
+    ("robot_model",         "mini_quadrotor",      "Name of the robot model ROS package"),
+    ("robot_ns",            "mini_quadrotor",      "Namespace for all robot nodes"),
+    ("real_machine",        "true",                "Use real machine specific bring-up inside model_launch", ["true", "false"]),
+    ("main_rate",           "40.0",                "Core node main loop rate [Hz]"),
+    ("estimation_mode",     "0",                   "Estimator mode on real machine: 0=egomotion, 1=experiment, 2=ground-truth", ["0", "1", "2"]),
+    ("model_options",       "",                    "Extra xacro arguments passed verbatim to xacro"),
+    ("headless",            "true",                "Run without GUI", ["true", "false"]),
+    ("sim",                 "false",               "Launch Gazebo simulation", ["true", "false"]),
+    ("sim_estimation_mode", "2",                   "Estimator mode in simulation: 0=egomotion, 1=experiment, 2=ground-truth", ["0", "1", "2"]),
+    ("spawn_x",             "0.0",                 "Gazebo spawn X position [m] (sim only)"),
+    ("spawn_y",             "0.0",                 "Gazebo spawn Y position [m] (sim only)"),
+    ("spawn_z",             "0.5",                 "Gazebo spawn Z position [m] (sim only)"),
+    ("robot_model_rviz",    "rviz_config.rviz",    "RViz config filename (resolved inside robot_model pkg/config/)"),
+]
+
+
+def sanity_check(context, *args, **kwargs):
+    # Evaulate AFTER substitutions (e.g., sim and estimation_mode) are resolved, but BEFORE any nodes are launched
+    # NOTE: Together with "choices" only real possibility to guardrail arguments
+    real_machine = LaunchConfiguration("real_machine").perform(context)
+    sim = LaunchConfiguration("sim").perform(context)
+    if real_machine.lower() == "true" and sim.lower() == "true":
+        raise RuntimeError("real_machine and sim arguments cannot both be true")
+
+    rate = float(LaunchConfiguration("main_rate").perform(context))
+    if rate <= 0 or rate > 200:
+        raise RuntimeError(f"main_rate={rate} is not as expected. ")
+
 
 def generate_launch_description():
+    # ------------------------------------------------------------------
+    # 1.  Declare CLI-overridable arguments
+    # ------------------------------------------------------------------
+    declared_args = [
+        DeclareLaunchArgument(
+            name,
+            default_value=default_value,
+            description=description,
+            **({"choices": choices[0]} if choices else {})
+        )
+        for name, default_value, description, *choices in _ARGS
+    ]
 
-    # --- LaunchConfiguration ---
-    headless         = LaunchConfiguration('headless')
-    model_options    = LaunchConfiguration('model_options')
-    robot_model_pkg  = LaunchConfiguration('robot_model')
-    robot_ns         = LaunchConfiguration('robot_ns')
-    robot_model_rviz = LaunchConfiguration('robot_model_rviz')
-    estimate_mode    = LaunchConfiguration('estimate_mode')
-    sim_estimate_mode= LaunchConfiguration('sim_estimate_mode')
-    sim       = LaunchConfiguration('sim')
-    rm       = LaunchConfiguration('rm')
-    spawn_x = LaunchConfiguration('spawn_x')
-    spawn_y = LaunchConfiguration('spawn_y')
-    spawn_z = LaunchConfiguration('spawn_z')
+    # Resolve / Read at launch time (NOT AT IMPORT TIME)
+    robot_model_pkg     = LaunchConfiguration("robot_model")
+    robot_ns            = LaunchConfiguration("robot_ns")
+    real_machine        = LaunchConfiguration("real_machine")
+    main_rate           = LaunchConfiguration("main_rate")
+    estimation_mode     = LaunchConfiguration("estimation_mode")
+    model_options       = LaunchConfiguration("model_options")
+    headless            = LaunchConfiguration("headless")
+    sim                 = LaunchConfiguration("sim")
+    sim_estimation_mode = LaunchConfiguration("sim_estimation_mode")
+    spawn_x             = LaunchConfiguration("spawn_x")
+    spawn_y             = LaunchConfiguration("spawn_y")
+    spawn_z             = LaunchConfiguration("spawn_z")
+    robot_model_rviz    = LaunchConfiguration("robot_model_rviz")
 
-    # --- DeclareLaunchArgument ---
-    headless_arg = DeclareLaunchArgument(
-        'headless',
-        default_value='False',
-        description='Run without GUI (headless mode)'
-    )
+    # TODO: get plugin name from yaml file
+    robot_model_plugin_name = {
+        "robot_model_plugin_name": ParameterValue(
+            "multirotor_robot_model",
+            value_type=str
+        )
+    }
 
-    model_options_arg = DeclareLaunchArgument(
-        'model_options',
-        default_value='',
-        description='Additional model options (e.g., extra URDF args)'
-    )
+    active_estimation_mode = PythonExpression([
+        "int('", sim_estimation_mode, "') if '", sim, "' == 'true' else int('", estimation_mode, "')"
+    ])
 
-    robot_model_pkg_arg = DeclareLaunchArgument(
-        'robot_model',
-        default_value='mini_quadrotor',
-        description='Name of the robot model package'
-    )
+    # ------------------------------------------------------------------
+    # 2.  Derived paths
+    # ------------------------------------------------------------------
+    state_estimation_path = PathJoinSubstitution([
+        FindPackageShare(robot_model_pkg),
+        "config", "StateEstimation.yaml",
+    ])
 
-    robot_ns_arg = DeclareLaunchArgument(
-        'robot_ns',
-        default_value='mini_quadrotor',
-        description='ROS namespace under which to launch the robot'
-    )
+    servo_param_path = PathJoinSubstitution([
+        FindPackageShare(robot_model_pkg),
+        "config", "Servo.yaml",
+    ])
 
-    robot_model_rviz_arg = DeclareLaunchArgument(
-        'robot_model_rviz',
-        default_value='rviz_config.rviz',
-        description='RViz display configuration for the robot model'
-    )
-
-    estimate_mode_arg = DeclareLaunchArgument(
-        'estimate_mode',
-        default_value='0',
-        description='Estimate mode (e.g., 0 for egomotion mode; 1 for experiment mode; 2 for ground truth mode)'
-    )
-
-    sim_estimate_mode_arg = DeclareLaunchArgument(
-        'sim_estimate_mode',
-        default_value='2',
-        description='Estimate mode in Simulation (e.g., 0 for egomotion mode; 1 for experiment mode; 2 for ground truth mode)'
-    )
-
-    simulation_arg = DeclareLaunchArgument(
-        'sim',
-        default_value='false',
-        description='Run in simulation mode (e.g., use Gazebo clock)'
-    )
-
-    realmachine_arg = DeclareLaunchArgument(
-        'rm',
-        default_value='false',
-        description='Run in realmachine mode'
-    )
-
-    spawn_x_arg = DeclareLaunchArgument(
-        'spawn_x',
-        default_value='0.0',
-        description='Initial X position'
-    )
-    spawn_y_arg = DeclareLaunchArgument(
-        'spawn_y',
-        default_value='0.0',
-        description='Initial Y position'
-    )
-    spawn_z_arg = DeclareLaunchArgument(
-        'spawn_z',
-        default_value='0.5',
-        description='Initial Z position'
-    )    
-
-    # --- robot_description parameter  ---
-    xacro_type = PythonExpression([
+    xacro_filename = PythonExpression([
         "'robot.gazebo.xacro' if '", sim, "' == 'true' else 'robot.urdf.xacro'"
     ])
-    
-    urdf_xacro = PathJoinSubstitution([
+
+    xacro_path = PathJoinSubstitution([
         FindPackageShare(robot_model_pkg),
-        'urdf',
-        xacro_type
+        "urdf", xacro_filename,
     ])
 
-    robot_description_content = Command([
-        'xacro ',
-        urdf_xacro,
-        model_options
-    ])
-    
-    robot_description = {
-        'robot_description':
-        ParameterValue(
-            robot_description_content,
+    # Build the URDF/xacro string via the xacro CLI.
+    # model_options is appended verbatim so callers can inject extra xacro args, e.g.,:
+    #   model_options:="prop_num:=6 payload:=true"
+    # and wrap in ParameterValue so ROS2 treats it as a string parameter
+    robot_description = [
+        FindExecutable(name="xacro"),
+        TextSubstitution(text=" "),
+        xacro_path,
+        TextSubstitution(text=" "),
+        model_options,
+    ]
+    robot_description_param = {
+        "robot_description": ParameterValue(
+            Command(robot_description),
             value_type=str
         )
     }
 
-    # --- simulation parameter  ---
-    sim_param_file = PathJoinSubstitution([
+    sim_param_path = PathJoinSubstitution([
         FindPackageShare(robot_model_pkg),
-        'config',
-        'Simulation.yaml',
-    ])    
-
-    # --- robot model parameter  TODO: get from yaml file---
-    robot_model_plugin_name = {
-        'robot_model_plugin_name':
-        ParameterValue(
-            'multirotor_robot_model',
-            value_type=str
-        )
-    }
-
-    # --- state estimation parameter  ---
-    state_estimation_file = PathJoinSubstitution([
-        FindPackageShare(robot_model_pkg),
-        'config',
-        'StateEstimation.yaml',
+        "config", "Simulation.yaml",
     ])
 
-    # --- rviz config path ---
-    rviz_config = PathJoinSubstitution([
+    # TODO: Use or remove
+    rviz_config_path = PathJoinSubstitution([
         FindPackageShare(robot_model_pkg),
-        'config',
-        robot_model_rviz
+        "config", robot_model_rviz
     ])
-    
-    # --- nodes ---
-    core_node =  Node(
-        package='aerial_robot_core',
-        executable='aerial_robot_core_node',
-        name='aerial_robot_core',
+
+    # ------------------------------------------------------------------
+    # 3.  Nodes
+    # ------------------------------------------------------------------
+    core_node = Node(
+        package="aerial_robot_core",
+        executable="aerial_robot_core_node",
+        name="aerial_robot_core",
         namespace=robot_ns,
         prefix=['gdb -ex run --args'],
-        parameters=[{'use_sim_time': sim,
-                     'main_rate': 40.0,
-                     'estimation.mode': PythonExpression([
-                         sim_estimate_mode, " if '", sim, "' == 'true' else '", estimate_mode, "'"])},
-                    robot_description,
-                    robot_model_plugin_name,
-                    state_estimation_file],
-        output = 'screen'
+        parameters=[
+            {
+                "main_rate": main_rate,
+                "estimation.mode": active_estimation_mode,
+                "use_sim_time": sim,
+            },
+            robot_description_param,
+            robot_model_plugin_name,
+            state_estimation_path,
+        ],
+        output="screen",
     )
 
+    # ------------------------------------------------------------------
+    # 4.  Call child launch files
+    # ------------------------------------------------------------------
+    # Robot model (URDF publisher, RViz, joint-state publisher …)
     model_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             PathJoinSubstitution([
-                FindPackageShare('aerial_robot_model'),
-                'launch',
-                'aerial_robot_model_launch.py'
+                FindPackageShare("aerial_robot_model"),
+                "launch", "aerial_robot_model_launch.py",
             ])
         ),
         launch_arguments={
-            'headless': LaunchConfiguration('headless'),
-            'rm': LaunchConfiguration('rm'),
-            'sim': LaunchConfiguration('sim'),
-            'model_options': LaunchConfiguration('model_options'),
-            'robot_model': LaunchConfiguration('robot_model'),
-            'robot_ns': LaunchConfiguration('robot_ns'),
-            'robot_model_rviz': LaunchConfiguration('robot_model_rviz'),
-            'robot_description_content': robot_description_content,
+            "robot_model": robot_model_pkg,
+            "robot_ns": robot_ns,
+            "real_machine": real_machine,
+            "model_options": model_options,
+            "headless": headless,
+            "robot_model_rviz": robot_model_rviz,
+            "robot_description": robot_description,
+            "sim": sim,
         }.items(),
     )
-    
+
+    # Gazebo simulation
     sim_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             PathJoinSubstitution([
-                FindPackageShare('aerial_robot_simulation'),
-                'launch',
-                'gazebo_launch.py'
+                FindPackageShare("aerial_robot_simulation"),
+                "launch", "gazebo_launch.py",
             ])
         ),
         launch_arguments={
-            'robot_name': LaunchConfiguration('robot_ns'),
-            'spawn_x': LaunchConfiguration('spawn_x'),
-            'spawn_y': LaunchConfiguration('spawn_y'),
-            'spawn_z': LaunchConfiguration('spawn_z'),
-            'sim_param_file':   sim_param_file,
-            'headless': LaunchConfiguration('headless'),
+            "robot_ns": robot_ns,
+            "headless": headless,
+            "sim_param_path": sim_param_path,
+            "spawn_x": spawn_x,
+            "spawn_y": spawn_y,
+            "spawn_z": spawn_z,
         }.items(),
         condition=IfCondition(sim),
     )
 
+    # ------------------------------------------------------------------
+    # 5.  Assemble LaunchDescription
+    # ------------------------------------------------------------------
     ld = LaunchDescription()
-    ld.add_action(headless_arg)
-    ld.add_action(model_options_arg)
-    ld.add_action(robot_model_pkg_arg)
-    ld.add_action(robot_ns_arg)
-    ld.add_action(robot_model_rviz_arg)
-    ld.add_action(estimate_mode_arg)
-    ld.add_action(sim_estimate_mode_arg)
-    ld.add_action(simulation_arg)
-    ld.add_action(realmachine_arg)
-    ld.add_action(spawn_x_arg)
-    ld.add_action(spawn_y_arg)
-    ld.add_action(spawn_z_arg)
+
+    for arg in declared_args:
+        ld.add_action(arg)
+
+    ld.add_action(OpaqueFunction(function=sanity_check))
     ld.add_action(core_node)
     ld.add_action(model_launch)
     ld.add_action(sim_launch)
+
     return ld


### PR DESCRIPTION
## WHAT IS THIS
Revised ruleset for clang-format in local pre-commit. Everything should be non-functional and only for cleaning the visual coding etiquette.

### Details
- Understood and adjusted each rule to unify the existing coding style as well as maximize readability (judged by Jojo)
- One key point is changing the pointer referencing from `int* a` to `int *a` (for `*` and `&`)
- Introduced comment capitalization through a script triggered in pre-commit for mostly all file formats
- Added the Python formatter "black" since it is widely adopted and "uncompromising" (one guideline - no options)
- Formatted estimation source files, joy_stick_launch.py, Servo.yaml and README.md as well as a CMakeLists.txt and a package.xml as examples
- (I accidentally worked on top of #19 so the changes are included here as well. Only focus on changes from commit [074f2df](https://github.com/ut-dragon-lab/aerial_robot_base/pull/20/commits/074f2df819308b67101b25069bb7aacfb23243e3) onwards)

### To-Do

- [ ] @tongtybj Please check if you like it or don't mind (either way please tell me)
- [ ] @sugihara-16 Please check if you like it or don't mind (either way please tell me)
- [ ] Apply this to all files currently existing
- [ ] Implement this on GitHub since it relied on the user manually setting it up (`pre-commit install`) and if someone is lazy they could ignore it