### PR TITLE
[Simulation] Workaround to use MuJoCo

### DIFF
--- a/.github/workflows/colcon_lint.yaml
+++ b/.github/workflows/colcon_lint.yaml
@@ -11,10 +11,13 @@ jobs:
   lint:
     name: Ament Build & Linters
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ros_distro: [humble]
     env:
-      ROS_DISTRO: humble  # Can be changed/updated
+      ROS_DISTRO: ${{ matrix.ros_distro }}
       DEBIAN_FRONTEND: noninteractive
-    container: ros:${ROS_DISTRO}
+    container: ros:${{ matrix.ros_distro }}
     defaults:
       run:
         shell: bash

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ colcon build --symlink-install
 source install/setup.bash
 ```
 
+### Optional MuJoCo runtime
+MuJoCo simulation uses the Python `mujoco` package at runtime. Register the workspace rosdep overlay before installing it:
+```bash
+cd ~/ros2/aerial_robot_base_ws/src/aerial_robot_base
+sudo sh -c "echo yaml file://$(pwd)/dependencies/rosdep/mujoco.yaml > /etc/ros/rosdep/sources.list.d/50-aerial-robot-mujoco.list"
+rosdep update
+AERIAL_ROBOT_WITH_MUJOCO=true rosdep install -y -r --from-paths aerial_robot_simulation --ignore-src --rosdistro ${ROS_DISTRO} --as-root pip:false
+```
+If your Python environment is managed separately, the equivalent package is `mujoco`.
+
 Setup pre-commit formatting
 ```bash
 cd ~/ros2/aerial_robot_base_ws/src/aerial_robot_base

--- a/aerial_robot_control/include/aerial_robot_control/LQI/under_actuated_lqi_controller.hpp
+++ b/aerial_robot_control/include/aerial_robot_control/LQI/under_actuated_lqi_controller.hpp
@@ -41,7 +41,6 @@
 #include "spinal_msgs/msg/roll_pitch_yaw_terms.hpp"
 #include "spinal_msgs/msg/p_matrix_pseudo_inverse_with_inertia.hpp"
 
-
 namespace aerial_robot_control
 {
 
@@ -90,6 +89,7 @@ protected:
   virtual void rosParamInit();
   rcl_interfaces::msg::SetParametersResult parametersCallback(const std::vector<rclcpp::Parameter> &parameters);
   void gainGeneratorFunc();
+  bool updateGain(bool publish_gain);
 
   virtual bool optimalGain();
   void resetGain() { K_ = Eigen::MatrixXd(); }

--- a/aerial_robot_control/src/LQI/under_actuated_lqi_controller.cpp
+++ b/aerial_robot_control/src/LQI/under_actuated_lqi_controller.cpp
@@ -36,7 +36,19 @@
 namespace aerial_robot_control
 {
 
-UnderActuatedLQIController::UnderActuatedLQIController() : target_roll_(0), target_pitch_(0), candidate_yaw_term_(0)
+UnderActuatedLQIController::UnderActuatedLQIController()
+  : gain_generate_rate_(15.0),
+    realtime_update_(false),
+    target_roll_(0),
+    target_pitch_(0),
+    candidate_yaw_term_(0),
+    lqi_mode_(4),
+    clamp_gain_(true),
+    has_optimal_gain_(false),
+    gyro_moment_compensation_(false),
+    verbose_(false),
+    trans_constraint_weight_(1.0),
+    att_control_weight_(1.0)
 {
   lqi_roll_pitch_weight_.setZero();
   lqi_yaw_weight_.setZero();
@@ -87,12 +99,16 @@ void UnderActuatedLQIController::initialize(rclcpp::Node::SharedPtr node,
   {
     gain_generator_thread_ = std::thread(std::bind(&UnderActuatedLQIController::gainGeneratorFunc, this));
   }
+  else
+  {
+    (void)updateGain(false);
+  }
 }
 
 UnderActuatedLQIController::~UnderActuatedLQIController()
 {
   // Clean up multithreading
-  if (realtime_update_)
+  if (gain_generator_thread_.joinable())
   {
     gain_generator_thread_.join();
   }
@@ -139,23 +155,7 @@ void UnderActuatedLQIController::gainGeneratorFunc()
 
   while (rclcpp::ok())
   {
-    if (robot_model_->initialized())
-    {
-      has_optimal_gain_ = optimalGain();
-      if (has_optimal_gain_)
-      {
-        clampGain();
-        sendGain();
-      }
-      else
-        RCLCPP_ERROR(node_->get_logger(), "[LQI] Cannot solve hamilton matrix!");
-    }
-    else
-    {
-      RCLCPP_DEBUG(node_->get_logger(), "[LQI] Robot model is not initialized!");
-      resetGain();
-    }
-
+    (void)updateGain(true);
     loop_rate.sleep();
   }
 }
@@ -164,10 +164,14 @@ void UnderActuatedLQIController::activate()
 {
   ControlBase::activate();
 
+  if (!has_optimal_gain_ && !realtime_update_)
+  {
+    (void)updateGain(false);
+  }
+
   // Publish gains during activation for general multirotor
   if (has_optimal_gain_)
   {
-    clampGain();
     sendGain();
     RCLCPP_INFO(node_->get_logger(), "[LQI] Send LQI gains");
   }
@@ -177,11 +181,36 @@ void UnderActuatedLQIController::activate()
   }
 }
 
+bool UnderActuatedLQIController::updateGain(bool publish_gain)
+{
+  if (!robot_model_->initialized())
+  {
+    RCLCPP_DEBUG(node_->get_logger(), "[LQI] Robot model is not initialized!");
+    resetGain();
+    has_optimal_gain_ = false;
+    return false;
+  }
+
+  has_optimal_gain_ = optimalGain();
+  if (!has_optimal_gain_)
+  {
+    RCLCPP_ERROR(node_->get_logger(), "[LQI] Cannot solve hamilton matrix!");
+    return false;
+  }
+
+  clampGain();
+  if (publish_gain)
+  {
+    sendGain();
+  }
+  return true;
+}
+
 bool UnderActuatedLQIController::optimalGain()
 {
   // Reference:
-  // M, Zhao, et.al, "Transformable multirotor with two-dimensional multilinks: modeling, control, and whole-body aerial
-  // manipulation" Sec. 3.2
+  // M, Zhao, et.al, "Transformable multirotor with two-dimensional multilinks:
+  // modeling, control, and whole-body aerial manipulation" Sec. 3.2
 
   Eigen::MatrixXd P = robot_model_->calcWrenchMatrixOnCoG();
   Eigen::MatrixXd P_dash = Eigen::MatrixXd::Zero(lqi_mode_, motor_num_);
@@ -232,13 +261,15 @@ bool UnderActuatedLQIController::optimalGain()
   if (K_.cols() == 0 || K_.rows() == 0)
   {
     RCLCPP_DEBUG_STREAM(node_->get_logger(),
-                        "[LQI] Gain generator: Not using Kleinman method since initial K is empty");
+                        "[LQI] Gain generator: Not using Kleinman method since "
+                        "initial K is empty");
     use_kleinman_method = false;
   }
   if (!control_utils::care(A, B, R, Q, K_, use_kleinman_method))
   {
     RCLCPP_ERROR(node_->get_logger(),
-                 "[LQI] Gain generator: Error in solver of continuous-time algebraic Riccati equation (CARE)");
+                 "[LQI] Gain generator: Error in solver of continuous-time "
+                 "algebraic Riccati equation (CARE)");
     return false;
   }
 
@@ -262,7 +293,8 @@ bool UnderActuatedLQIController::optimalGain()
 
 void UnderActuatedLQIController::clampGain()
 {
-  /* Avoid the violation of 16int_t range because of spinal::RollPitchYawTerms */
+  /* Avoid the violation of 16int_t range because of spinal::RollPitchYawTerms
+   */
   double max_gain_thresh = 32.767;
   double max_roll_p_gain = 0, max_roll_d_gain = 0, max_pitch_p_gain = 0, max_pitch_d_gain = 0, max_yaw_d_gain = 0;
   for (int i = 0; i < motor_num_; ++i)
@@ -278,31 +310,41 @@ void UnderActuatedLQIController::clampGain()
          yaw_d_gain_scale = 1;
   if (max_roll_p_gain > max_gain_thresh)
   {
-    RCLCPP_WARN(node_->get_logger(), "[LQI] Gain generator: the max roll p gain violate the range of int16_t: %f",
+    RCLCPP_WARN(node_->get_logger(),
+                "[LQI] Gain generator: the max roll p gain violate the range "
+                "of int16_t: %f",
                 max_roll_p_gain);
     roll_p_gain_scale = max_gain_thresh / max_roll_p_gain;
   }
   if (max_roll_d_gain > max_gain_thresh)
   {
-    RCLCPP_WARN(node_->get_logger(), "[LQI] Gain generator: the max roll d gain violate the range of int16_t: %f",
+    RCLCPP_WARN(node_->get_logger(),
+                "[LQI] Gain generator: the max roll d gain violate the range "
+                "of int16_t: %f",
                 max_roll_d_gain);
     roll_d_gain_scale = max_gain_thresh / max_roll_d_gain;
   }
   if (max_pitch_p_gain > max_gain_thresh)
   {
-    RCLCPP_WARN(node_->get_logger(), "[LQI] Gain generator: the max pitch p gain violate the range of int16_t: %f",
+    RCLCPP_WARN(node_->get_logger(),
+                "[LQI] Gain generator: the max pitch p gain violate the range "
+                "of int16_t: %f",
                 max_pitch_p_gain);
     pitch_p_gain_scale = max_gain_thresh / max_pitch_p_gain;
   }
   if (max_pitch_d_gain > max_gain_thresh)
   {
-    RCLCPP_WARN(node_->get_logger(), "[LQI] Gain generator: the max pitch d gain violate the range of int16_t: %f",
+    RCLCPP_WARN(node_->get_logger(),
+                "[LQI] Gain generator: the max pitch d gain violate the range "
+                "of int16_t: %f",
                 max_pitch_d_gain);
     pitch_d_gain_scale = max_gain_thresh / max_pitch_d_gain;
   }
   if (max_yaw_d_gain > max_gain_thresh)
   {
-    RCLCPP_WARN(node_->get_logger(), "[LQI] Gain generator: the max yaw d gain violate the range of int16_t: %f",
+    RCLCPP_WARN(node_->get_logger(),
+                "[LQI] Gain generator: the max yaw d gain violate the range of "
+                "int16_t: %f",
                 max_yaw_d_gain);
     yaw_d_gain_scale = max_gain_thresh / max_yaw_d_gain;
   }
@@ -406,7 +448,8 @@ void UnderActuatedLQIController::allocateYawTerm()
     target_thrust_yaw_term *= (1 - residual / max_term);
   }
 
-  // Special process for yaw because of the limited bandwidth between PC and spinal
+  // Special process for yaw because of the limited bandwidth between PC and
+  // spinal
   double max_yaw_scale = 0;  // To reconstruct yaw control term in spinal
   for (int i = 0; i < motor_num_; i++)
   {
@@ -509,7 +552,6 @@ void UnderActuatedLQIController::sendRotationalInertiaComp()
 
   p_matrix_pseudo_inverse_inertia_pub_->publish(p_pseudo_inverse_with_inertia_msg);
 }
-
 
 rcl_interfaces::msg::SetParametersResult UnderActuatedLQIController::parametersCallback(
     const std::vector<rclcpp::Parameter> &parameters)
@@ -626,16 +668,7 @@ rcl_interfaces::msg::SetParametersResult UnderActuatedLQIController::parametersC
   if (!realtime_update_)
   {
     // Instantly modify gain if model has no joints, i.e., is fixed
-    has_optimal_gain_ = optimalGain();
-    if (has_optimal_gain_)
-    {
-      clampGain();
-      sendGain();
-    }
-    else
-    {
-      RCLCPP_ERROR(node_->get_logger(), "[LQI] Cannot solve hamilton matrix!");
-    }
+    (void)updateGain(true);
   }
   return result;
 }

--- a/aerial_robot_core/include/aerial_robot_core/aerial_robot_core.hpp
+++ b/aerial_robot_core/include/aerial_robot_core/aerial_robot_core.hpp
@@ -60,6 +60,11 @@ public:
 private:
   bool param_verbose_;
   double main_rate_;
+  bool warn_main_rate_;
+  double main_rate_warn_tolerance_;
+  int main_rate_warn_throttle_ms_;
+  int main_rate_warn_warmup_count_;
+  int main_rate_warn_count_{ 0 };
   rclcpp::TimerBase::SharedPtr main_timer_;
 
   rclcpp::Clock steady_clock_{ RCL_STEADY_TIME };

--- a/aerial_robot_core/src/aerial_robot_core.cpp
+++ b/aerial_robot_core/src/aerial_robot_core.cpp
@@ -43,6 +43,10 @@ AerialRobotCore::AerialRobotCore(rclcpp::Node::SharedPtr node)
   // Get parameters from launch file
   node_->get_parameter_or("param_verbose", param_verbose_, false);
   node_->get_parameter_or("main_rate", main_rate_, 1.0);
+  node_->get_parameter_or("warn_main_rate", warn_main_rate_, true);
+  node_->get_parameter_or("main_rate_warn_tolerance", main_rate_warn_tolerance_, 0.20);
+  node_->get_parameter_or("main_rate_warn_throttle_ms", main_rate_warn_throttle_ms_, 5000);
+  node_->get_parameter_or("main_rate_warn_warmup_count", main_rate_warn_warmup_count_, 10);
   double main_dt = 1.0 / main_rate_;
 
   if (param_verbose_) RCLCPP_INFO(node_->get_logger(), "%s: main rate is %f Hz", node_->get_namespace(), main_rate_);
@@ -51,6 +55,22 @@ AerialRobotCore::AerialRobotCore(rclcpp::Node::SharedPtr node)
   {
     RCLCPP_ERROR(node_->get_logger(), "Main rate is zero or negative!");
     return;
+  }
+
+  if (main_rate_warn_tolerance_ < 0.0)
+  {
+    RCLCPP_WARN(node_->get_logger(), "main_rate_warn_tolerance must be non-negative. Use 0.0 instead.");
+    main_rate_warn_tolerance_ = 0.0;
+  }
+  if (main_rate_warn_throttle_ms_ <= 0)
+  {
+    RCLCPP_WARN(node_->get_logger(), "main_rate_warn_throttle_ms must be positive. Use 5000 ms instead.");
+    main_rate_warn_throttle_ms_ = 5000;
+  }
+  if (main_rate_warn_warmup_count_ < 0)
+  {
+    RCLCPP_WARN(node_->get_logger(), "main_rate_warn_warmup_count must be non-negative. Use 0 instead.");
+    main_rate_warn_warmup_count_ = 0;
   }
 
   /* Model */
@@ -95,12 +115,16 @@ void AerialRobotCore::mainFunc()
   if (last_main_time_ns_ != 0)
   {
     const double dt_real = static_cast<double>(now_ns - last_main_time_ns_) * 1e-9;
-    const double tolerance = 0.05;  // 5% tolerance
-    const double dt_desire = (1.0 + tolerance) * 1.0 / main_rate_;
-    if (dt_real > dt_desire)
+    const double dt_desire = (1.0 + main_rate_warn_tolerance_) * 1.0 / main_rate_;
+    if (main_rate_warn_count_ < main_rate_warn_warmup_count_)
     {
-      RCLCPP_WARN(node_->get_logger(), "Main loop rate is too low: (ts_real) %f s > (ts_desire incl. %2f%% tol) %f s",
-                  dt_real, tolerance * 100, dt_desire);
+      ++main_rate_warn_count_;
+    }
+    else if (warn_main_rate_ && dt_real > dt_desire)
+    {
+      RCLCPP_WARN_THROTTLE(node_->get_logger(), steady_clock_, main_rate_warn_throttle_ms_,
+                           "Main loop rate is too low: (ts_real) %f s > (ts_desire incl. %2f%% tol) %f s",
+                           dt_real, main_rate_warn_tolerance_ * 100, dt_desire);
     }
   }
   last_main_time_ns_ = now_ns;  // In nanosecons

--- a/aerial_robot_core/src/aerial_robot_core.cpp
+++ b/aerial_robot_core/src/aerial_robot_core.cpp
@@ -123,8 +123,8 @@ void AerialRobotCore::mainFunc()
     else if (warn_main_rate_ && dt_real > dt_desire)
     {
       RCLCPP_WARN_THROTTLE(node_->get_logger(), steady_clock_, main_rate_warn_throttle_ms_,
-                           "Main loop rate is too low: (ts_real) %f s > (ts_desire incl. %2f%% tol) %f s",
-                           dt_real, main_rate_warn_tolerance_ * 100, dt_desire);
+                           "Main loop rate is too low: (ts_real) %f s > (ts_desire incl. %2f%% tol) %f s", dt_real,
+                           main_rate_warn_tolerance_ * 100, dt_desire);
     }
   }
   last_main_time_ns_ = now_ns;  // In nanosecons

--- a/aerial_robot_estimation/CMakeLists.txt
+++ b/aerial_robot_estimation/CMakeLists.txt
@@ -113,6 +113,7 @@ ament_export_dependencies(
 # --- Linters ---
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  set(AMENT_LINT_AUTO_EXCLUDE ament_cmake_pep257)
   ament_lint_auto_find_test_dependencies()
 endif()
 

--- a/aerial_robot_model/CMakeLists.txt
+++ b/aerial_robot_model/CMakeLists.txt
@@ -173,6 +173,7 @@ target_link_libraries(interactive_marker_tf_broadcaster)
 # --- Jacobian test------------------------------
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  set(AMENT_LINT_AUTO_EXCLUDE ament_cmake_pep257)
   ament_lint_auto_find_test_dependencies()
   find_package(ament_cmake_gtest REQUIRED)
 

--- a/aerial_robot_model/src/model/plugin/multirotor_robot_model.cpp
+++ b/aerial_robot_model/src/model/plugin/multirotor_robot_model.cpp
@@ -37,11 +37,14 @@
 
 MultirotorRobotModel::MultirotorRobotModel() : RobotModel() {}
 
-void MultirotorRobotModel::initialize(rclcpp::Node::SharedPtr node, bool init_with_rosparam, bool verbose,
-                                      bool fixed_model, double fc_f_min_thre, double fc_t_min_thre, double epsilon) {
-  fixed_model = false;
-  aerial_robot_model::RobotModel::initialize(std::move(node), init_with_rosparam, verbose, fixed_model, fc_f_min_thre,
-                                             fc_t_min_thre, epsilon);
+void MultirotorRobotModel::initialize(rclcpp::Node::SharedPtr node,
+                                      bool init_with_rosparam, bool verbose,
+                                      bool fixed_model, double fc_f_min_thre,
+                                      double fc_t_min_thre, double epsilon) {
+  node->get_parameter_or("robot_model_fixed", fixed_model, false);
+  aerial_robot_model::RobotModel::initialize(
+      std::move(node), init_with_rosparam, verbose, fixed_model, fc_f_min_thre,
+      fc_t_min_thre, epsilon);
 }
 
 /* plugin registration */

--- a/aerial_robot_navigation/CMakeLists.txt
+++ b/aerial_robot_navigation/CMakeLists.txt
@@ -34,7 +34,7 @@ set(ROS_DEPENDENCIES
 )
 
 # --- Build flight_navigation library ---
-add_library (flight_navigation
+add_library(flight_navigation
   src/flight_navigation.cpp
   src/util/joy_parser.cpp
   src/trajectory/reference_base.cpp

--- a/aerial_robot_simulation/CMakeLists.txt
+++ b/aerial_robot_simulation/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(controller_interface REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
+find_package(rosgraph_msgs REQUIRED)
 find_package(aerial_robot_model REQUIRED)
 find_package(aerial_robot_msgs REQUIRED)
 find_package(spinal REQUIRED)
@@ -73,6 +74,7 @@ ament_target_dependencies(spinal_interface
 )
 target_link_libraries(spinal_interface
   rotor_handle_lib
+  spinal::spinal_math
 )
 
 add_library(aerial_robot_hw_sim SHARED
@@ -121,6 +123,20 @@ ament_target_dependencies(sim_param_server
   rclcpp
 )
 
+add_executable(mujoco_attitude_controller src/mujoco_attitude_controller_node.cpp)
+ament_target_dependencies(mujoco_attitude_controller
+  rclcpp
+  rclcpp_lifecycle
+  sensor_msgs
+  nav_msgs
+  spinal
+)
+target_link_libraries(mujoco_attitude_controller
+  spinal_interface
+  spinal::spinal_math
+  spinal::spinal_flight_control
+)
+
 
 pluginlib_export_plugin_description_file(
   gz_ros2_control
@@ -134,7 +150,8 @@ pluginlib_export_plugin_description_file(
 
 
 install(
-  TARGETS rotor_handle_lib spinal_interface aerial_robot_hw_sim simulation_attitude_controller sim_param_server
+  TARGETS rotor_handle_lib spinal_interface aerial_robot_hw_sim simulation_attitude_controller
+          sim_param_server mujoco_attitude_controller
   EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
@@ -149,6 +166,11 @@ install(
 install(
   DIRECTORY launch xacro config gazebo_model
   DESTINATION share/${PROJECT_NAME}
+)
+
+install(PROGRAMS
+  scripts/mujoco_bridge.py
+  DESTINATION lib/${PROJECT_NAME}
 )
 
 install(

--- a/aerial_robot_simulation/CMakeLists.txt
+++ b/aerial_robot_simulation/CMakeLists.txt
@@ -109,9 +109,11 @@ ament_target_dependencies(simulation_attitude_controller
   gz_ros2_control
   ignition-gazebo6
   controller_interface
+  spinal
 )
 target_link_libraries(simulation_attitude_controller
   spinal_interface
+  spinal::spinal_flight_control
 )
 
 add_executable(sim_param_server src/sim_param_server.cpp)

--- a/aerial_robot_simulation/include/aerial_robot_simulation/simulation_attitude_controller.h
+++ b/aerial_robot_simulation/include/aerial_robot_simulation/simulation_attitude_controller.h
@@ -36,13 +36,13 @@
 #define SIMULATION_ATTITUDE_CONTROLLER_H
 
 #include <aerial_robot_simulation/spinal_interface.h>
+#include <flight_control/simulation/flight_control_ros_module.h>
+#include <thruster/simulation/thruster_ros_module.h>
 
 #include <boost/scoped_ptr.hpp>
-// #include <flight_control/flight_control.h>
 #include <urdf/model.h>
 
 #include <memory>
-#include <spinal_msgs/msg/desire_coord.hpp>
 #include <std_msgs/msg/float64.hpp>
 #include <string>
 
@@ -71,6 +71,10 @@ public:
 
 private:
   hardware_interface::SpinalInterface spinal_iface_;
+  ThrusterRosModule thruster_ros_mod_;
+  FlightControlRosModule flight_control_ros_mod_;
+
+  void writeRotorCommands_();
 };
 
 }

--- a/aerial_robot_simulation/launch/mujoco_launch.py
+++ b/aerial_robot_simulation/launch/mujoco_launch.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, RegisterEventHandler, Shutdown
+from launch.event_handlers import OnProcessExit
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+
+_ARGS = [
+    ("robot_ns", "mini_quadrotor", "Namespace for all robot nodes"),
+    ("headless", "true", "Run without GUI", ["true", "false"]),
+    ("viewer_font_scale", "100", "MuJoCo viewer UI font scale percent; set 0 to keep MuJoCo default"),
+    ("mujoco_model", "", "MuJoCo MJCF/XML model path. Generate from URDF/Xacro when empty or missing"),
+    ("mujoco_urdf_xacro", "", "URDF/Xacro path used when MuJoCo XML must be generated"),
+    ("mujoco_xacro_options", "", "Extra xacro arguments used for generated MuJoCo XML"),
+    ("generated_model_dir", "/tmp/aerial_robot_mujoco", "Directory for generated MuJoCo XML/assets"),
+    ("sim_param_path", "", "Path to YAML file with simulation parameters"),
+    ("spawn_x", "0.0", "MuJoCo spawn X position [m]"),
+    ("spawn_y", "0.0", "MuJoCo spawn Y position [m]"),
+    ("spawn_z", "0.5", "MuJoCo spawn Z position [m]"),
+]
+
+
+def generate_launch_description():
+    declared_args = [
+        DeclareLaunchArgument(
+            name,
+            default_value=default_value,
+            description=description,
+            **({"choices": choices[0]} if choices else {}),
+        )
+        for name, default_value, description, *choices in _ARGS
+    ]
+
+    robot_ns = LaunchConfiguration("robot_ns")
+    headless = LaunchConfiguration("headless")
+    viewer_font_scale = LaunchConfiguration("viewer_font_scale")
+    mujoco_model = LaunchConfiguration("mujoco_model")
+    mujoco_urdf_xacro = LaunchConfiguration("mujoco_urdf_xacro")
+    mujoco_xacro_options = LaunchConfiguration("mujoco_xacro_options")
+    generated_model_dir = LaunchConfiguration("generated_model_dir")
+    sim_param_path = LaunchConfiguration("sim_param_path")
+    spawn_x = LaunchConfiguration("spawn_x")
+    spawn_y = LaunchConfiguration("spawn_y")
+    spawn_z = LaunchConfiguration("spawn_z")
+
+    sim_param_server = Node(
+        package="aerial_robot_simulation",
+        executable="sim_param_server",
+        name="sim_param_server",
+        namespace=robot_ns,
+        parameters=[sim_param_path],
+        output="screen",
+    )
+
+    mujoco_bridge = Node(
+        package="aerial_robot_simulation",
+        executable="mujoco_bridge.py",
+        name="mujoco_bridge",
+        namespace=robot_ns,
+        parameters=[
+            sim_param_path,
+            {
+                "model_path": mujoco_model,
+                "urdf_xacro_path": mujoco_urdf_xacro,
+                "xacro_options": mujoco_xacro_options,
+                "generated_model_dir": generated_model_dir,
+                "headless": ParameterValue(headless, value_type=bool),
+                "viewer_font_scale": ParameterValue(viewer_font_scale, value_type=int),
+                "spawn_x": ParameterValue(spawn_x, value_type=float),
+                "spawn_y": ParameterValue(spawn_y, value_type=float),
+                "spawn_z": ParameterValue(spawn_z, value_type=float),
+                "use_sim_time": True,
+            },
+        ],
+        output="screen",
+    )
+
+    attitude_controller = Node(
+        package="aerial_robot_simulation",
+        executable="mujoco_attitude_controller",
+        name="mujoco_attitude_controller",
+        namespace=robot_ns,
+        parameters=[
+            sim_param_path,
+            {"use_sim_time": True},
+        ],
+        output="screen",
+    )
+
+    shutdown_handler = RegisterEventHandler(
+        OnProcessExit(
+            target_action=mujoco_bridge,
+            on_exit=[Shutdown()],
+        )
+    )
+
+    ld = LaunchDescription()
+    for arg in declared_args:
+        ld.add_action(arg)
+
+    ld.add_action(sim_param_server)
+    ld.add_action(attitude_controller)
+    ld.add_action(mujoco_bridge)
+    ld.add_action(shutdown_handler)
+    return ld

--- a/aerial_robot_simulation/package.xml
+++ b/aerial_robot_simulation/package.xml
@@ -14,6 +14,7 @@
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
+  <depend>rosgraph_msgs</depend>
   <depend>aerial_robot_msgs</depend>
   <depend>spinal</depend>
   <depend>controller_manager_msgs</depend>
@@ -31,6 +32,10 @@
   <depend>ros2_controllers</depend>
   <depend>controller_interface</depend>
   <depend>ros_gz_bridge</depend>
+  <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <exec_depend condition="$AERIAL_ROBOT_WITH_MUJOCO == 'true'">python3-mujoco</exec_depend>
 
   <!-- Linters -->
   <test_depend>ament_lint_auto</test_depend>

--- a/aerial_robot_simulation/scripts/mujoco_bridge.py
+++ b/aerial_robot_simulation/scripts/mujoco_bridge.py
@@ -1,0 +1,1112 @@
+#!/usr/bin/env python3
+"""Run a MuJoCo model and bridge its aerial-robot sensors/actuators to ROS 2."""
+
+import hashlib
+import math
+import os
+import random
+import re
+import signal
+import shlex
+import shutil
+import subprocess
+import sys
+import time
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import rclpy
+from geometry_msgs.msg import PoseStamped
+from nav_msgs.msg import Odometry
+from rclpy.node import Node
+from rosgraph_msgs.msg import Clock
+from sensor_msgs.msg import Imu, JointState, MagneticField
+
+
+_MJCF_GENERATOR_VERSION = "urdf_to_mjcf_v2"
+_MUJOCO_VIEWER_FONT_SCALES = (50, 100, 150, 200, 250, 300)
+
+
+def _xml_name(tag):
+    return tag.rsplit("}", 1)[-1]
+
+
+def _children(elem, name):
+    return [child for child in elem if _xml_name(child.tag) == name]
+
+
+def _first_child(elem, name):
+    for child in elem:
+        if _xml_name(child.tag) == name:
+            return child
+    return None
+
+
+def _descendants(elem, name):
+    return [child for child in elem.iter() if _xml_name(child.tag) == name]
+
+
+def _parse_vec(text, default):
+    if text is None:
+        return list(default)
+    values = [float(item) for item in text.split()]
+    if len(values) < len(default):
+        values.extend(default[len(values) :])
+    return values[: len(default)]
+
+
+def _format_float(value):
+    if abs(value) < 1.0e-12:
+        value = 0.0
+    return f"{value:.9g}"
+
+
+def _format_vec(values):
+    return " ".join(_format_float(float(value)) for value in values)
+
+
+def _safe_name(name):
+    safe = re.sub(r"[^A-Za-z0-9_]+", "_", name)
+    safe = safe.strip("_")
+    return safe or "mesh"
+
+
+class UrdfToMjcfGenerator:
+    """Small URDF-to-MJCF converter for aerial-robot simulation models."""
+
+    def __init__(self, logger):
+        self.logger = logger
+        self.output_path = None
+        self.assets_dir = None
+        self.asset = None
+        self.links = {}
+        self.parent_joints = {}
+        self.mesh_assets = {}
+        self.rotor_sites = []
+        self.m_f_rate = 0.0
+
+    def generate(self, urdf_xml, output_path):
+        self.output_path = Path(output_path)
+        self.assets_dir = self.output_path.parent / "assets"
+        self.output_path.parent.mkdir(parents=True, exist_ok=True)
+        self.assets_dir.mkdir(parents=True, exist_ok=True)
+        self.mesh_assets = {}
+        self.rotor_sites = []
+
+        urdf_root = ET.fromstring(urdf_xml)
+        robot_name = _safe_name(urdf_root.get("name", "robot"))
+        self.links = {link.get("name"): link for link in _children(urdf_root, "link") if link.get("name")}
+        self.parent_joints = {}
+        child_links = set()
+        for joint in _children(urdf_root, "joint"):
+            parent = _first_child(joint, "parent")
+            child = _first_child(joint, "child")
+            if parent is None or child is None:
+                continue
+            parent_name = parent.get("link")
+            child_name = child.get("link")
+            if not parent_name or not child_name:
+                continue
+            self.parent_joints.setdefault(parent_name, []).append(joint)
+            child_links.add(child_name)
+
+        root_links = [name for name in self.links if name not in child_links]
+        if not root_links:
+            raise RuntimeError("URDF does not contain a root link")
+        dynamic_root = self._select_dynamic_root(root_links[0])
+        self.m_f_rate = self._read_float_element(urdf_root, "m_f_rate", 0.0)
+
+        mjcf_root = ET.Element("mujoco", {"model": robot_name})
+        ET.SubElement(
+            mjcf_root,
+            "compiler",
+            {"angle": "radian", "inertiafromgeom": "false", "meshdir": "assets"},
+        )
+        ET.SubElement(
+            mjcf_root,
+            "option",
+            {"timestep": "0.001", "integrator": "RK4", "gravity": "0 0 -9.80665"},
+        )
+
+        self.asset = ET.SubElement(mjcf_root, "asset")
+        ET.SubElement(
+            self.asset,
+            "texture",
+            {
+                "name": "checker",
+                "type": "2d",
+                "builtin": "checker",
+                "width": "512",
+                "height": "512",
+                "rgb1": "0.02 0.04 0.07",
+                "rgb2": "0.10 0.20 0.32",
+            },
+        )
+        ET.SubElement(
+            self.asset,
+            "material",
+            {"name": "checker", "texture": "checker", "texrepeat": "10 10", "reflectance": "0.25"},
+        )
+
+        default = ET.SubElement(mjcf_root, "default")
+        ET.SubElement(default, "geom", {"condim": "3", "friction": "0.8 0.1 0.1"})
+        ET.SubElement(default, "site", {"size": "0.004", "rgba": "0.1 0.8 0.1 1"})
+        visual_default = ET.SubElement(default, "default", {"class": "visual"})
+        ET.SubElement(visual_default, "geom", {"contype": "0", "conaffinity": "0", "group": "1"})
+        collision_default = ET.SubElement(default, "default", {"class": "collision"})
+        ET.SubElement(collision_default, "geom", {"rgba": "0 0 0 0", "group": "3"})
+
+        visual = ET.SubElement(mjcf_root, "visual")
+        ET.SubElement(visual, "global", {"offwidth": "1280", "offheight": "720"})
+
+        worldbody = ET.SubElement(mjcf_root, "worldbody")
+        ET.SubElement(worldbody, "light", {"name": "sun", "pos": "0 0 3", "dir": "0 0 -1"})
+        ET.SubElement(
+            worldbody,
+            "geom",
+            {"name": "ground", "type": "plane", "size": "6 6 0.02", "material": "checker"},
+        )
+
+        root_body = ET.SubElement(worldbody, "body", {"name": dynamic_root, "pos": "0 0 0"})
+        ET.SubElement(root_body, "freejoint", {"name": "root"})
+        self._add_link(root_body, dynamic_root)
+
+        actuator = ET.SubElement(mjcf_root, "actuator")
+        for rotor_name, max_force, yaw_gear in self.rotor_sites:
+            ET.SubElement(
+                actuator,
+                "motor",
+                {
+                    "name": rotor_name,
+                    "site": rotor_name,
+                    "gear": _format_vec((0.0, 0.0, 1.0, 0.0, 0.0, yaw_gear)),
+                    "ctrlrange": f"0 {_format_float(max_force)}",
+                    "ctrllimited": "true",
+                },
+            )
+
+        sensor = ET.SubElement(mjcf_root, "sensor")
+        ET.SubElement(sensor, "accelerometer", {"name": "acc", "site": "fc"})
+        ET.SubElement(sensor, "gyro", {"name": "gyro", "site": "fc"})
+        ET.SubElement(sensor, "magnetometer", {"name": "mag", "site": "fc"})
+        ET.SubElement(sensor, "framelinvel", {"name": "fc_vel", "objtype": "site", "objname": "fc"})
+        ET.SubElement(sensor, "frameangvel", {"name": "fc_angvel", "objtype": "site", "objname": "fc"})
+
+        if not self._has_site(root_body, "fc"):
+            ET.SubElement(root_body, "site", {"name": "fc", "pos": "0 0 0"})
+
+        ET.indent(mjcf_root, space="  ")
+        ET.ElementTree(mjcf_root).write(self.output_path, encoding="utf-8", xml_declaration=True)
+        return self.output_path
+
+    def _select_dynamic_root(self, root_link_name):
+        root_link = self.links[root_link_name]
+        children = self.parent_joints.get(root_link_name, [])
+        if not self._link_has_content(root_link) and len(children) == 1:
+            joint = children[0]
+            if joint.get("type", "fixed") == "fixed":
+                child = _first_child(joint, "child")
+                if child is not None and child.get("link") in self.links:
+                    return child.get("link")
+        return root_link_name
+
+    def _link_has_content(self, link):
+        if _children(link, "visual") or _children(link, "collision"):
+            return True
+        inertial = _first_child(link, "inertial")
+        if inertial is None:
+            return False
+        mass = _first_child(inertial, "mass")
+        return mass is not None and float(mass.get("value", "0")) > 1.0e-9
+
+    def _add_link(self, body, link_name):
+        link = self.links[link_name]
+        self._add_inertial(body, link)
+        self._add_geometries(body, link, "visual")
+        self._add_geometries(body, link, "collision")
+
+        if link_name == "fc" and not self._has_site(body, "fc"):
+            ET.SubElement(body, "site", {"name": "fc", "pos": "0 0 0"})
+
+        for joint in self.parent_joints.get(link_name, []):
+            child = _first_child(joint, "child")
+            if child is None or child.get("link") not in self.links:
+                continue
+            child_name = child.get("link")
+            origin_xyz, origin_rpy = self._origin(joint)
+            attrs = {"name": child_name, "pos": _format_vec(origin_xyz)}
+            if any(abs(value) > 1.0e-12 for value in origin_rpy):
+                attrs["euler"] = _format_vec(origin_rpy)
+            child_body = ET.SubElement(body, "body", attrs)
+
+            joint_name = joint.get("name", "")
+            if self._is_rotor_joint(joint):
+                ET.SubElement(child_body, "site", {"name": joint_name, "pos": "0 0 0"})
+                self.rotor_sites.append(self._rotor_actuator_info(joint))
+
+            self._add_link(child_body, child_name)
+
+    def _add_inertial(self, body, link):
+        inertial = _first_child(link, "inertial")
+        if inertial is None:
+            return
+
+        mass_elem = _first_child(inertial, "mass")
+        if mass_elem is None:
+            return
+        mass = float(mass_elem.get("value", "0"))
+        if mass <= 1.0e-9:
+            return
+
+        inertia_elem = _first_child(inertial, "inertia")
+        if inertia_elem is None:
+            return
+        origin_xyz, origin_rpy = self._origin(inertial)
+        attrs = {
+            "mass": _format_float(mass),
+            "pos": _format_vec(origin_xyz),
+            "fullinertia": _format_vec(
+                (
+                    float(inertia_elem.get("ixx", "0")),
+                    float(inertia_elem.get("iyy", "0")),
+                    float(inertia_elem.get("izz", "0")),
+                    float(inertia_elem.get("ixy", "0")),
+                    float(inertia_elem.get("ixz", "0")),
+                    float(inertia_elem.get("iyz", "0")),
+                )
+            ),
+        }
+        if any(abs(value) > 1.0e-12 for value in origin_rpy):
+            attrs["euler"] = _format_vec(origin_rpy)
+        ET.SubElement(body, "inertial", attrs)
+
+    def _add_geometries(self, body, link, kind):
+        for index, geom_parent in enumerate(_children(link, kind)):
+            geometry = _first_child(geom_parent, "geometry")
+            if geometry is None:
+                continue
+            geom_attrs = {
+                "name": f"{link.get('name')}_{kind}_{index}",
+                "class": kind,
+            }
+            origin_xyz, origin_rpy = self._origin(geom_parent)
+            if any(abs(value) > 1.0e-12 for value in origin_xyz):
+                geom_attrs["pos"] = _format_vec(origin_xyz)
+            if any(abs(value) > 1.0e-12 for value in origin_rpy):
+                geom_attrs["euler"] = _format_vec(origin_rpy)
+
+            if not self._set_geometry_attrs(geom_attrs, geometry):
+                continue
+            if kind == "visual":
+                geom_attrs.setdefault("rgba", self._visual_rgba(link.get("name", "")))
+            ET.SubElement(body, "geom", geom_attrs)
+
+    def _set_geometry_attrs(self, geom_attrs, geometry):
+        mesh = _first_child(geometry, "mesh")
+        if mesh is not None:
+            filename = mesh.get("filename")
+            if not filename:
+                return False
+            scale = _parse_vec(mesh.get("scale"), (1.0, 1.0, 1.0))
+            mesh_name = self._register_mesh(filename, scale)
+            if not mesh_name:
+                return False
+            geom_attrs["type"] = "mesh"
+            geom_attrs["mesh"] = mesh_name
+            return True
+
+        box = _first_child(geometry, "box")
+        if box is not None:
+            size = _parse_vec(box.get("size"), (0.0, 0.0, 0.0))
+            geom_attrs["type"] = "box"
+            geom_attrs["size"] = _format_vec([value * 0.5 for value in size])
+            return True
+
+        cylinder = _first_child(geometry, "cylinder")
+        if cylinder is not None:
+            radius = float(cylinder.get("radius", "0"))
+            length = float(cylinder.get("length", "0"))
+            geom_attrs["type"] = "cylinder"
+            geom_attrs["size"] = _format_vec((radius, length * 0.5))
+            return True
+
+        sphere = _first_child(geometry, "sphere")
+        if sphere is not None:
+            geom_attrs["type"] = "sphere"
+            geom_attrs["size"] = _format_float(float(sphere.get("radius", "0")))
+            return True
+
+        return False
+
+    def _register_mesh(self, uri, scale):
+        source_path = self._resolve_mesh_path(uri)
+        key = (str(source_path), tuple(scale))
+        if key in self.mesh_assets:
+            return self.mesh_assets[key]
+
+        digest = hashlib.sha1(f"{source_path}:{scale}".encode()).hexdigest()[:10]
+        mesh_name = f"{_safe_name(source_path.stem)}_{digest}"
+        suffix = source_path.suffix.lower()
+
+        if suffix == ".dae":
+            dest_name = f"{mesh_name}.obj"
+            self._convert_collada_to_obj(source_path, self.assets_dir / dest_name)
+        elif suffix in (".obj", ".stl"):
+            dest_name = f"{mesh_name}{suffix}"
+            shutil.copy2(source_path, self.assets_dir / dest_name)
+        else:
+            self.logger.warn(f"Unsupported mesh format for MuJoCo conversion: {source_path}")
+            return None
+
+        attrs = {"name": mesh_name, "file": dest_name}
+        if any(abs(value - 1.0) > 1.0e-12 for value in scale):
+            attrs["scale"] = _format_vec(scale)
+        ET.SubElement(self.asset, "mesh", attrs)
+        self.mesh_assets[key] = mesh_name
+        return mesh_name
+
+    def _resolve_mesh_path(self, uri):
+        if uri.startswith("package://"):
+            package_path = uri[len("package://") :]
+            package_name, relative_path = package_path.split("/", 1)
+            from ament_index_python.packages import get_package_share_directory
+
+            path = Path(get_package_share_directory(package_name)) / relative_path
+        elif uri.startswith("file://"):
+            path = Path(uri[len("file://") :])
+        else:
+            path = Path(uri)
+            if not path.is_absolute() and self.output_path is not None:
+                path = (Path.cwd() / path).resolve()
+
+        if not path.is_file():
+            raise FileNotFoundError(f"Mesh file does not exist: {uri} -> {path}")
+        return path
+
+    def _convert_collada_to_obj(self, source_path, dest_path):
+        root = ET.parse(source_path).getroot()
+        unit = 1.0
+        unit_elems = _descendants(root, "unit")
+        if unit_elems:
+            unit = float(unit_elems[0].get("meter", "1.0"))
+
+        geometry_meshes = {}
+        for geometry in _descendants(root, "geometry"):
+            mesh = _first_child(geometry, "mesh")
+            geometry_id = geometry.get("id")
+            if mesh is not None and geometry_id:
+                geometry_meshes[geometry_id] = mesh
+
+        instances = self._collada_geometry_instances(root)
+        vertices = []
+        faces = []
+        if instances:
+            for geometry_id, transform in instances:
+                mesh = geometry_meshes.get(geometry_id)
+                if mesh is not None:
+                    self._append_collada_mesh(mesh, unit, transform, vertices, faces)
+        else:
+            for mesh in geometry_meshes.values():
+                self._append_collada_mesh(mesh, unit, self._identity_matrix(), vertices, faces)
+
+        if not vertices or not faces:
+            raise RuntimeError(f"Collada mesh contains no supported triangles/polylist: {source_path}")
+
+        with open(dest_path, "w", encoding="utf-8") as obj:
+            obj.write(f"# Generated from {source_path.name}\n")
+            for vertex in vertices:
+                obj.write(f"v {_format_vec(vertex)}\n")
+            for face in faces:
+                obj.write(f"f {face[0]} {face[1]} {face[2]}\n")
+
+    def _collada_geometry_instances(self, root):
+        instances = []
+        for visual_scene in _descendants(root, "visual_scene"):
+            self._collect_collada_instances(visual_scene, self._identity_matrix(), instances)
+        return instances
+
+    def _collect_collada_instances(self, elem, parent_transform, instances):
+        for child in elem:
+            if _xml_name(child.tag) != "node":
+                continue
+            transform = parent_transform
+            matrix_elem = _first_child(child, "matrix")
+            if matrix_elem is not None and matrix_elem.text:
+                transform = self._matrix_multiply(parent_transform, self._matrix_from_text(matrix_elem.text))
+            for instance in _children(child, "instance_geometry"):
+                geometry_id = instance.get("url", "").lstrip("#")
+                if geometry_id:
+                    instances.append((geometry_id, transform))
+            self._collect_collada_instances(child, transform, instances)
+
+    def _append_collada_mesh(self, mesh, unit, transform, vertices, faces):
+        sources = {}
+        for source in _children(mesh, "source"):
+            source_id = source.get("id")
+            float_array = _first_child(source, "float_array")
+            if not source_id or float_array is None or not float_array.text:
+                continue
+            accessor = _descendants(source, "accessor")
+            stride = int(accessor[0].get("stride", "3")) if accessor else 3
+            sources[source_id] = ([float(value) for value in float_array.text.split()], stride)
+
+        vertex_sources = {}
+        for vertices_elem in _children(mesh, "vertices"):
+            vertices_id = vertices_elem.get("id")
+            if not vertices_id:
+                continue
+            for input_elem in _children(vertices_elem, "input"):
+                if input_elem.get("semantic") == "POSITION":
+                    vertex_sources[vertices_id] = input_elem.get("source", "").lstrip("#")
+
+        for primitive in mesh:
+            primitive_type = _xml_name(primitive.tag)
+            if primitive_type == "triangles":
+                self._append_collada_triangles(primitive, sources, vertex_sources, unit, transform, vertices, faces)
+            elif primitive_type == "polylist":
+                self._append_collada_polylist(primitive, sources, vertex_sources, unit, transform, vertices, faces)
+            elif primitive_type == "polygons":
+                self._append_collada_polygons(primitive, sources, vertex_sources, unit, transform, vertices, faces)
+
+    def _collada_position_input(self, primitive, vertex_sources):
+        inputs = _children(primitive, "input")
+        for input_elem in inputs:
+            semantic = input_elem.get("semantic")
+            if semantic not in ("VERTEX", "POSITION"):
+                continue
+            source_id = input_elem.get("source", "").lstrip("#")
+            if semantic == "VERTEX":
+                source_id = vertex_sources.get(source_id)
+            if source_id:
+                tuple_stride = max(int(item.get("offset", "0")) for item in inputs) + 1
+                offset = int(input_elem.get("offset", "0"))
+                return source_id, offset, tuple_stride
+        return None, 0, 0
+
+    def _append_collada_triangles(self, primitive, sources, vertex_sources, unit, transform, vertices, faces):
+        source_id, offset, tuple_stride = self._collada_position_input(primitive, vertex_sources)
+        if source_id not in sources or tuple_stride <= 0:
+            return
+        p_elem = _first_child(primitive, "p")
+        if p_elem is None or not p_elem.text:
+            return
+        indices = [int(value) for value in p_elem.text.split()]
+        for cursor in range(0, len(indices), tuple_stride * 3):
+            if cursor + tuple_stride * 3 > len(indices):
+                break
+            face = []
+            for corner in range(3):
+                vertex_index = indices[cursor + corner * tuple_stride + offset]
+                face.append(self._append_obj_vertex(sources[source_id], vertex_index, unit, transform, vertices))
+            faces.append(tuple(face))
+
+    def _append_collada_polylist(self, primitive, sources, vertex_sources, unit, transform, vertices, faces):
+        source_id, offset, tuple_stride = self._collada_position_input(primitive, vertex_sources)
+        if source_id not in sources or tuple_stride <= 0:
+            return
+        p_elem = _first_child(primitive, "p")
+        vcount_elem = _first_child(primitive, "vcount")
+        if p_elem is None or vcount_elem is None or not p_elem.text or not vcount_elem.text:
+            return
+        indices = [int(value) for value in p_elem.text.split()]
+        vertex_counts = [int(value) for value in vcount_elem.text.split()]
+        cursor = 0
+        for vertex_count in vertex_counts:
+            polygon = []
+            for corner in range(vertex_count):
+                vertex_index = indices[cursor + corner * tuple_stride + offset]
+                polygon.append(self._append_obj_vertex(sources[source_id], vertex_index, unit, transform, vertices))
+            cursor += vertex_count * tuple_stride
+            self._triangulate_polygon(polygon, faces)
+
+    def _append_collada_polygons(self, primitive, sources, vertex_sources, unit, transform, vertices, faces):
+        source_id, offset, tuple_stride = self._collada_position_input(primitive, vertex_sources)
+        if source_id not in sources or tuple_stride <= 0:
+            return
+        for p_elem in _children(primitive, "p"):
+            if not p_elem.text:
+                continue
+            indices = [int(value) for value in p_elem.text.split()]
+            polygon = []
+            for cursor in range(0, len(indices), tuple_stride):
+                vertex_index = indices[cursor + offset]
+                polygon.append(self._append_obj_vertex(sources[source_id], vertex_index, unit, transform, vertices))
+            self._triangulate_polygon(polygon, faces)
+
+    def _append_obj_vertex(self, source, vertex_index, unit, transform, vertices):
+        values, stride = source
+        base = vertex_index * stride
+        if base + 2 >= len(values):
+            raise RuntimeError(f"Collada vertex index out of range: {vertex_index}")
+        point = self._transform_point(transform, (values[base], values[base + 1], values[base + 2]))
+        vertices.append((point[0] * unit, point[1] * unit, point[2] * unit))
+        return len(vertices)
+
+    def _identity_matrix(self):
+        return [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+
+    def _matrix_from_text(self, text):
+        values = [float(value) for value in text.split()]
+        if len(values) != 16:
+            raise RuntimeError("Collada transform matrix must contain 16 values")
+        return [values[index : index + 4] for index in range(0, 16, 4)]
+
+    def _matrix_multiply(self, lhs, rhs):
+        return [
+            [sum(lhs[row][k] * rhs[k][col] for k in range(4)) for col in range(4)]
+            for row in range(4)
+        ]
+
+    def _transform_point(self, matrix, point):
+        x, y, z = point
+        return (
+            matrix[0][0] * x + matrix[0][1] * y + matrix[0][2] * z + matrix[0][3],
+            matrix[1][0] * x + matrix[1][1] * y + matrix[1][2] * z + matrix[1][3],
+            matrix[2][0] * x + matrix[2][1] * y + matrix[2][2] * z + matrix[2][3],
+        )
+
+    def _triangulate_polygon(self, polygon, faces):
+        if len(polygon) < 3:
+            return
+        for index in range(1, len(polygon) - 1):
+            faces.append((polygon[0], polygon[index], polygon[index + 1]))
+
+    def _rotor_actuator_info(self, joint):
+        joint_name = joint.get("name", "")
+        axis_elem = _first_child(joint, "axis")
+        axis = _parse_vec(axis_elem.get("xyz") if axis_elem is not None else None, (0.0, 0.0, 1.0))
+        limit = _first_child(joint, "limit")
+        max_force = float(limit.get("upper", "8.0")) if limit is not None else 8.0
+        yaw_gear = axis[2] * self.m_f_rate
+        return joint_name, max_force, yaw_gear
+
+    def _is_rotor_joint(self, joint):
+        return joint.get("name", "").startswith("rotor")
+
+    def _origin(self, elem):
+        origin = _first_child(elem, "origin")
+        if origin is None:
+            return [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]
+        return _parse_vec(origin.get("xyz"), (0.0, 0.0, 0.0)), _parse_vec(origin.get("rpy"), (0.0, 0.0, 0.0))
+
+    def _visual_rgba(self, link_name):
+        lowered = link_name.lower()
+        if "battery" in lowered:
+            return "0.04 0.04 0.04 1"
+        if "thrust" in lowered or "rotor" in lowered or "prop" in lowered:
+            return "0.05 0.05 0.05 0.75"
+        return "0.55 0.60 0.62 1"
+
+    def _read_float_element(self, root, name, default):
+        elem = _first_child(root, name)
+        if elem is None:
+            return default
+        return float(elem.get("value", str(default)))
+
+    def _has_site(self, body, site_name):
+        return any(elem.get("name") == site_name for elem in _descendants(body, "site"))
+
+
+class MujocoBridge(Node):
+    def __init__(self):
+        super().__init__("mujoco_bridge")
+
+        self.declare_parameter("model_path", "")
+        self.declare_parameter("urdf_xacro_path", "")
+        self.declare_parameter("xacro_options", "")
+        self.declare_parameter("generated_model_dir", "/tmp/aerial_robot_mujoco")
+        self.declare_parameter("headless", True)
+        self.declare_parameter("viewer_font_scale", 100)
+        self.declare_parameter("step_rate", 1000.0)
+        self.declare_parameter("render_rate", 60.0)
+        self.declare_parameter("spawn_x", 0.0)
+        self.declare_parameter("spawn_y", 0.0)
+        self.declare_parameter("spawn_z", 0.5)
+        self.declare_parameter("rotor_joints", ["rotor1", "rotor2", "rotor3", "rotor4"])
+
+        self.declare_parameter("ground_truth_pub_rate", 0.01)
+        self.declare_parameter("ground_truth_pos_noise", 0.0)
+        self.declare_parameter("ground_truth_vel_noise", 0.0)
+        self.declare_parameter("ground_truth_rot_noise", 0.0)
+        self.declare_parameter("ground_truth_angular_noise", 0.0)
+        self.declare_parameter("mocap_pub_rate", 0.01)
+        self.declare_parameter("mocap_pos_noise", 0.001)
+        self.declare_parameter("mocap_rot_noise", 0.001)
+
+        self.model_path_arg = str(self.get_parameter("model_path").value).strip()
+        self.urdf_xacro_path = str(self.get_parameter("urdf_xacro_path").value).strip()
+        self.xacro_options = str(self.get_parameter("xacro_options").value).strip()
+        self.generated_model_dir = Path(os.path.expanduser(str(self.get_parameter("generated_model_dir").value)))
+        self.model_path = None
+        self.headless = bool(self.get_parameter("headless").value)
+        self.viewer_font_scale = int(self.get_parameter("viewer_font_scale").value)
+        self.step_rate = max(1.0, float(self.get_parameter("step_rate").value))
+        self.render_period = 1.0 / max(1.0, float(self.get_parameter("render_rate").value))
+        self.rotor_joints = list(self.get_parameter("rotor_joints").value)
+
+        self.ground_truth_period = max(0.0, float(self.get_parameter("ground_truth_pub_rate").value))
+        self.ground_truth_pos_noise = float(self.get_parameter("ground_truth_pos_noise").value)
+        self.ground_truth_vel_noise = float(self.get_parameter("ground_truth_vel_noise").value)
+        self.ground_truth_rot_noise = float(self.get_parameter("ground_truth_rot_noise").value)
+        self.ground_truth_angular_noise = float(self.get_parameter("ground_truth_angular_noise").value)
+        self.mocap_period = max(0.0, float(self.get_parameter("mocap_pub_rate").value))
+        self.mocap_pos_noise = float(self.get_parameter("mocap_pos_noise").value)
+        self.mocap_rot_noise = float(self.get_parameter("mocap_rot_noise").value)
+
+        self.clock_pub = self.create_publisher(Clock, "/clock", 10)
+        self.imu_pub = self.create_publisher(Imu, "mujoco/imu", 10)
+        self.mag_pub = self.create_publisher(MagneticField, "mujoco/mag", 10)
+        self.ground_truth_pub = self.create_publisher(Odometry, "ground_truth", 10)
+        self.mocap_pub = self.create_publisher(PoseStamped, "mocap/pose", 10)
+        self.create_subscription(JointState, "mujoco/rotor_forces", self._rotor_force_callback, 10)
+
+        self.rotor_force = {name: 0.0 for name in self.rotor_joints}
+        self.last_ground_truth_pub_time = -1.0
+        self.last_mocap_pub_time = -1.0
+
+    def _rotor_force_callback(self, msg):
+        if msg.name and msg.effort:
+            for name, effort in zip(msg.name, msg.effort):
+                if name in self.rotor_force:
+                    self.rotor_force[name] = max(0.0, float(effort))
+            return
+
+        for name, effort in zip(self.rotor_joints, msg.effort):
+            self.rotor_force[name] = max(0.0, float(effort))
+
+    def run(self):
+        try:
+            import mujoco
+            import numpy as np
+        except ImportError as exc:
+            self.get_logger().fatal(
+                "Python package 'mujoco' is required for Mujoco simulation. "
+                "Install the optional rosdep key 'python3-mujoco' from "
+                "src/aerial_robot_base/dependencies/rosdep/mujoco.yaml."
+            )
+            raise SystemExit(1) from exc
+
+        self.model_path = self._resolve_model_path()
+        if not self.model_path.is_file():
+            self.get_logger().fatal(f"MuJoCo model file does not exist: {self.model_path}")
+            raise SystemExit(1)
+
+        model = mujoco.MjModel.from_xml_path(str(self.model_path))
+        data = mujoco.MjData(model)
+        self._set_initial_pose(mujoco, model, data)
+
+        actuator_ids = self._collect_actuators(mujoco, model)
+        sensor_ids = self._collect_sensors(mujoco, model)
+        fc_site_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SITE, "fc")
+        main_body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "main_body")
+        if fc_site_id < 0 or main_body_id < 0:
+            self.get_logger().fatal("MuJoCo model must define site 'fc' and body 'main_body'")
+            raise SystemExit(1)
+
+        viewer = None
+        previous_sigint_handler = None
+        if not self.headless:
+            try:
+                import mujoco.viewer
+
+                viewer = mujoco.viewer.launch_passive(model, data)
+                self._configure_viewer_font_scale(viewer, model, data)
+                previous_sigint_handler = signal.getsignal(signal.SIGINT)
+                signal.signal(signal.SIGINT, self._exit_gui_process)
+            except Exception as exc:  # noqa: BLE001 - report viewer setup failures without hiding headless use.
+                self.get_logger().error(f"Failed to start MuJoCo viewer: {exc}")
+                raise
+
+        mujoco.mj_forward(model, data)
+        self.get_logger().info(
+            f"[mujoco] started {self.model_path} with {len(actuator_ids)} rotor actuators at {self.step_rate:.1f} Hz"
+        )
+
+        step_period = 1.0 / self.step_rate
+        last_render = time.monotonic()
+
+        try:
+            while rclpy.ok() and (viewer is None or viewer.is_running()):
+                loop_start = time.monotonic()
+                try:
+                    rclpy.spin_once(self, timeout_sec=0.0)
+                except (KeyboardInterrupt, RuntimeError):
+                    if not rclpy.ok():
+                        break
+                    raise
+
+                self._apply_rotor_forces(data, actuator_ids)
+                mujoco.mj_step(model, data)
+                self._publish_clock(data.time)
+                self._publish_sensors(mujoco, np, model, data, sensor_ids, fc_site_id, main_body_id)
+
+                if viewer is not None and time.monotonic() - last_render >= self.render_period:
+                    viewer.sync()
+                    last_render = time.monotonic()
+
+                elapsed = time.monotonic() - loop_start
+                if elapsed < step_period:
+                    time.sleep(step_period - elapsed)
+        finally:
+            if previous_sigint_handler is not None:
+                signal.signal(signal.SIGINT, previous_sigint_handler)
+            if viewer is not None:
+                try:
+                    viewer.close()
+                except KeyboardInterrupt:
+                    pass
+
+    def _configure_viewer_font_scale(self, viewer, model, data):
+        if self.viewer_font_scale <= 0:
+            return
+        if self.viewer_font_scale not in _MUJOCO_VIEWER_FONT_SCALES:
+            self.get_logger().warn(
+                "viewer_font_scale must be one of "
+                f"{_MUJOCO_VIEWER_FONT_SCALES}; keeping MuJoCo default"
+            )
+            return
+
+        sim = viewer._get_sim()  # MuJoCo does not expose viewer font scale in its public Python API.
+        if sim is None:
+            self.get_logger().warn("Could not access MuJoCo viewer state to set font scale")
+            return
+
+        font_index = _MUJOCO_VIEWER_FONT_SCALES.index(self.viewer_font_scale)
+        if not self._write_viewer_font_index(sim, font_index):
+            self.get_logger().warn("Could not set MuJoCo viewer font scale; keeping MuJoCo default")
+            return
+
+        # Reloading the same model lets MuJoCo recreate mjrContext with the updated font index.
+        sim.load(model, data, str(self.model_path))
+        self.get_logger().info(f"[mujoco] viewer font scale set to {self.viewer_font_scale}%")
+
+    def _write_viewer_font_index(self, sim, font_index):
+        import ctypes
+
+        readable_ranges = self._readable_memory_ranges()
+        if not readable_ranges:
+            return False
+
+        pointer_size = ctypes.sizeof(ctypes.c_void_p)
+        object_size = sys.getsizeof(sim)
+        pointer_count = object_size // pointer_size
+        if pointer_count < 3:
+            return False
+
+        sentinel_ui0 = 0x13572468
+        sentinel_ui1 = 0x24681357
+        original_ui0 = int(sim.ui0_enable)
+        original_ui1 = int(sim.ui1_enable)
+
+        try:
+            sim.ui0_enable = sentinel_ui0
+            sim.ui1_enable = sentinel_ui1
+            pyobject_ptrs = (ctypes.c_void_p * pointer_count).from_address(id(sim))
+
+            for pointer_index in range(2, pointer_count):
+                wrapper_ptr = pyobject_ptrs[pointer_index]
+                if not self._is_readable_address(wrapper_ptr, pointer_size, readable_ranges):
+                    continue
+
+                simulate_ptr = ctypes.c_void_p.from_address(wrapper_ptr).value
+                scan_bytes = 16 * 1024
+                if not self._is_readable_address(simulate_ptr, scan_bytes, readable_ranges):
+                    continue
+
+                values = (ctypes.c_int * (scan_bytes // ctypes.sizeof(ctypes.c_int))).from_address(simulate_ptr)
+                for offset_index in range(len(values) - 1):
+                    if values[offset_index] != sentinel_ui0 or values[offset_index + 1] != sentinel_ui1:
+                        continue
+
+                    font_offset_index = offset_index - 1
+                    if font_offset_index < 0 or values[font_offset_index] not in range(len(_MUJOCO_VIEWER_FONT_SCALES)):
+                        continue
+                    values[font_offset_index] = font_index
+                    return True
+        finally:
+            sim.ui0_enable = original_ui0
+            sim.ui1_enable = original_ui1
+
+        return False
+
+    def _readable_memory_ranges(self):
+        ranges = []
+        try:
+            with open("/proc/self/maps", "r", encoding="utf-8") as maps_file:
+                for line in maps_file:
+                    columns = line.split()
+                    if len(columns) < 2 or "r" not in columns[1]:
+                        continue
+                    start, end = columns[0].split("-", 1)
+                    ranges.append((int(start, 16), int(end, 16)))
+        except OSError:
+            return []
+        return ranges
+
+    def _is_readable_address(self, address, size, readable_ranges):
+        if not address or address < 0x10000:
+            return False
+        end_address = address + size
+        return any(start <= address and end_address <= end for start, end in readable_ranges)
+
+    def _set_initial_pose(self, mujoco, model, data):
+        root_joint_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "root")
+        if root_joint_id < 0:
+            return
+
+        qpos_addr = model.jnt_qposadr[root_joint_id]
+        data.qpos[qpos_addr + 0] = float(self.get_parameter("spawn_x").value)
+        data.qpos[qpos_addr + 1] = float(self.get_parameter("spawn_y").value)
+        data.qpos[qpos_addr + 2] = float(self.get_parameter("spawn_z").value)
+        mujoco.mj_forward(model, data)
+
+    def _resolve_model_path(self):
+        if self.model_path_arg:
+            candidate = Path(os.path.expanduser(self.model_path_arg))
+            if candidate.is_file():
+                return candidate
+            self.get_logger().warn(
+                f"MuJoCo model file is missing, generating one from URDF/Xacro instead: {candidate}"
+            )
+
+        if not self.urdf_xacro_path:
+            self.get_logger().fatal(
+                "MuJoCo model path was empty or missing and no urdf_xacro_path parameter was provided"
+            )
+            raise SystemExit(1)
+
+        xacro_path = Path(os.path.expanduser(self.urdf_xacro_path))
+        if not xacro_path.is_file():
+            self.get_logger().fatal(f"URDF/Xacro file does not exist: {xacro_path}")
+            raise SystemExit(1)
+
+        xacro_executable = shutil.which("xacro")
+        if xacro_executable is None:
+            self.get_logger().fatal("xacro executable was not found in PATH")
+            raise SystemExit(1)
+
+        command = [xacro_executable, str(xacro_path)] + shlex.split(self.xacro_options)
+        try:
+            completed = subprocess.run(command, check=True, capture_output=True, text=True)
+        except subprocess.CalledProcessError as exc:
+            self.get_logger().fatal(f"xacro failed for {xacro_path}: {exc.stderr.strip()}")
+            raise SystemExit(1) from exc
+
+        urdf_xml = completed.stdout
+        robot_name = "robot"
+        try:
+            robot_name = _safe_name(ET.fromstring(urdf_xml).get("name", "robot"))
+        except ET.ParseError:
+            pass
+        digest = hashlib.sha1(
+            f"{_MJCF_GENERATOR_VERSION}\n{xacro_path}\n{self.xacro_options}\n{urdf_xml}".encode()
+        ).hexdigest()[:12]
+        output_path = self.generated_model_dir / robot_name / digest / "robot.xml"
+        generator = UrdfToMjcfGenerator(self.get_logger())
+        try:
+            generated_path = generator.generate(urdf_xml, output_path)
+        except Exception as exc:  # noqa: BLE001 - report generator failures as launch-time errors.
+            self.get_logger().fatal(f"Failed to generate MuJoCo model from {xacro_path}: {exc}")
+            raise SystemExit(1) from exc
+
+        self.get_logger().info(f"[mujoco] generated model from {xacro_path}: {generated_path}")
+        return generated_path
+
+    def _collect_actuators(self, mujoco, model):
+        actuator_ids = {}
+        for rotor_name in self.rotor_joints:
+            actuator_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, rotor_name)
+            if actuator_id < 0:
+                self.get_logger().warn(f"MuJoCo actuator '{rotor_name}' was not found")
+                continue
+            actuator_ids[rotor_name] = actuator_id
+        return actuator_ids
+
+    def _collect_sensors(self, mujoco, model):
+        sensor_ids = {}
+        for name in ("acc", "gyro", "mag", "fc_vel", "fc_angvel"):
+            sensor_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SENSOR, name)
+            if sensor_id >= 0:
+                sensor_ids[name] = sensor_id
+            else:
+                self.get_logger().warn(f"MuJoCo sensor '{name}' was not found")
+        return sensor_ids
+
+    def _sensor_vec(self, model, data, sensor_ids, name, default):
+        sensor_id = sensor_ids.get(name)
+        if sensor_id is None:
+            return default
+        addr = model.sensor_adr[sensor_id]
+        dim = model.sensor_dim[sensor_id]
+        values = data.sensordata[addr : addr + dim]
+        if dim < len(default):
+            return tuple(default)
+        return tuple(float(values[i]) for i in range(len(default)))
+
+    def _apply_rotor_forces(self, data, actuator_ids):
+        for rotor_name, actuator_id in actuator_ids.items():
+            data.ctrl[actuator_id] = self.rotor_force.get(rotor_name, 0.0)
+
+    def _publish_clock(self, sim_time):
+        msg = Clock()
+        msg.clock.sec = int(sim_time)
+        msg.clock.nanosec = int((sim_time - msg.clock.sec) * 1.0e9)
+        self.clock_pub.publish(msg)
+
+    def _publish_sensors(self, mujoco, np, model, data, sensor_ids, fc_site_id, main_body_id):
+        stamp = self.get_clock().now().to_msg()
+        acc = self._sensor_vec(model, data, sensor_ids, "acc", (0.0, 0.0, 9.80665))
+        gyro = self._sensor_vec(model, data, sensor_ids, "gyro", (0.0, 0.0, 0.0))
+        mag = self._sensor_vec(model, data, sensor_ids, "mag", (0.0, 0.0, 0.0))
+        linear_vel = self._sensor_vec(model, data, sensor_ids, "fc_vel", (0.0, 0.0, 0.0))
+        angular_vel = self._sensor_vec(model, data, sensor_ids, "fc_angvel", gyro)
+
+        fc_quat = np.zeros(4)
+        mujoco.mju_mat2Quat(fc_quat, data.site_xmat[fc_site_id])
+
+        imu_msg = Imu()
+        imu_msg.header.stamp = stamp
+        imu_msg.header.frame_id = "fc"
+        imu_msg.orientation.w = float(fc_quat[0])
+        imu_msg.orientation.x = float(fc_quat[1])
+        imu_msg.orientation.y = float(fc_quat[2])
+        imu_msg.orientation.z = float(fc_quat[3])
+        imu_msg.angular_velocity.x = gyro[0]
+        imu_msg.angular_velocity.y = gyro[1]
+        imu_msg.angular_velocity.z = gyro[2]
+        imu_msg.linear_acceleration.x = acc[0]
+        imu_msg.linear_acceleration.y = acc[1]
+        imu_msg.linear_acceleration.z = acc[2]
+        self.imu_pub.publish(imu_msg)
+
+        mag_msg = MagneticField()
+        mag_msg.header.stamp = stamp
+        mag_msg.header.frame_id = "magnet"
+        mag_msg.magnetic_field.x = mag[0]
+        mag_msg.magnetic_field.y = mag[1]
+        mag_msg.magnetic_field.z = mag[2]
+        self.mag_pub.publish(mag_msg)
+
+        if self.ground_truth_period == 0.0 or data.time - self.last_ground_truth_pub_time >= self.ground_truth_period:
+            self._publish_ground_truth(stamp, data, fc_site_id, fc_quat, linear_vel, angular_vel)
+
+        if self.mocap_period == 0.0 or data.time - self.last_mocap_pub_time >= self.mocap_period:
+            self._publish_mocap(stamp, data, fc_site_id, fc_quat)
+
+        _ = main_body_id
+
+    def _publish_ground_truth(self, stamp, data, fc_site_id, fc_quat, linear_vel, angular_vel):
+        msg = Odometry()
+        msg.header.stamp = stamp
+        msg.header.frame_id = "world"
+        msg.child_frame_id = "fc"
+
+        pos = data.site_xpos[fc_site_id]
+        msg.pose.pose.position.x = float(pos[0] + self._noise(self.ground_truth_pos_noise))
+        msg.pose.pose.position.y = float(pos[1] + self._noise(self.ground_truth_pos_noise))
+        msg.pose.pose.position.z = float(pos[2] + self._noise(self.ground_truth_pos_noise))
+
+        noisy_quat = self._apply_quat_noise(fc_quat, self.ground_truth_rot_noise)
+        self._set_ros_quat(msg.pose.pose.orientation, noisy_quat)
+
+        msg.twist.twist.linear.x = linear_vel[0] + self._noise(self.ground_truth_vel_noise)
+        msg.twist.twist.linear.y = linear_vel[1] + self._noise(self.ground_truth_vel_noise)
+        msg.twist.twist.linear.z = linear_vel[2] + self._noise(self.ground_truth_vel_noise)
+        msg.twist.twist.angular.x = angular_vel[0] + self._noise(self.ground_truth_angular_noise)
+        msg.twist.twist.angular.y = angular_vel[1] + self._noise(self.ground_truth_angular_noise)
+        msg.twist.twist.angular.z = angular_vel[2] + self._noise(self.ground_truth_angular_noise)
+
+        self.ground_truth_pub.publish(msg)
+        self.last_ground_truth_pub_time = float(data.time)
+
+    def _publish_mocap(self, stamp, data, fc_site_id, fc_quat):
+        msg = PoseStamped()
+        msg.header.stamp = stamp
+        msg.header.frame_id = "world"
+
+        pos = data.site_xpos[fc_site_id]
+        msg.pose.position.x = float(pos[0] + self._noise(self.mocap_pos_noise))
+        msg.pose.position.y = float(pos[1] + self._noise(self.mocap_pos_noise))
+        msg.pose.position.z = float(pos[2] + self._noise(self.mocap_pos_noise))
+        self._set_ros_quat(msg.pose.orientation, self._apply_quat_noise(fc_quat, self.mocap_rot_noise))
+
+        self.mocap_pub.publish(msg)
+        self.last_mocap_pub_time = float(data.time)
+
+    def _noise(self, sigma):
+        if sigma <= 0.0:
+            return 0.0
+        return random.gauss(0.0, sigma)
+
+    def _apply_quat_noise(self, quat_wxyz, sigma):
+        if sigma <= 0.0:
+            return quat_wxyz
+        dq = self._rpy_to_quat(self._noise(sigma), self._noise(sigma), self._noise(sigma))
+        return self._quat_multiply(quat_wxyz, dq)
+
+    @staticmethod
+    def _rpy_to_quat(roll, pitch, yaw):
+        cr = math.cos(roll * 0.5)
+        sr = math.sin(roll * 0.5)
+        cp = math.cos(pitch * 0.5)
+        sp = math.sin(pitch * 0.5)
+        cy = math.cos(yaw * 0.5)
+        sy = math.sin(yaw * 0.5)
+        return (
+            cr * cp * cy + sr * sp * sy,
+            sr * cp * cy - cr * sp * sy,
+            cr * sp * cy + sr * cp * sy,
+            cr * cp * sy - sr * sp * cy,
+        )
+
+    @staticmethod
+    def _quat_multiply(lhs, rhs):
+        lw, lx, ly, lz = lhs
+        rw, rx, ry, rz = rhs
+        return (
+            lw * rw - lx * rx - ly * ry - lz * rz,
+            lw * rx + lx * rw + ly * rz - lz * ry,
+            lw * ry - lx * rz + ly * rw + lz * rx,
+            lw * rz + lx * ry - ly * rx + lz * rw,
+        )
+
+    @staticmethod
+    def _set_ros_quat(dst, quat_wxyz):
+        dst.w = float(quat_wxyz[0])
+        dst.x = float(quat_wxyz[1])
+        dst.y = float(quat_wxyz[2])
+        dst.z = float(quat_wxyz[3])
+
+    @staticmethod
+    def _exit_gui_process(signum, frame):
+        _ = signum
+        _ = frame
+        os._exit(0)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = MujocoBridge()
+    try:
+        node.run()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        try:
+            node.destroy_node()
+        except KeyboardInterrupt:
+            pass
+        try:
+            if rclpy.ok():
+                rclpy.shutdown()
+        except KeyboardInterrupt:
+            pass
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/aerial_robot_simulation/src/aerial_robot_hw_sim.cpp
+++ b/aerial_robot_simulation/src/aerial_robot_hw_sim.cpp
@@ -344,14 +344,12 @@ bool AerialRobotHwSim::initSim(rclcpp::Node::SharedPtr &model_nh, std::map<std::
     try
     {
       rotor_visual_speed_rate = std::stod(rotor_visual_speed_rate_it->second);
-      RCLCPP_INFO_STREAM(this->nh_->get_logger(), "[sim] Loaded rotor_visual_speed_rate: "
-                                                     << rotor_visual_speed_rate);
+      RCLCPP_INFO_STREAM(this->nh_->get_logger(), "[sim] Loaded rotor_visual_speed_rate: " << rotor_visual_speed_rate);
     }
     catch (const std::exception &)
     {
-      RCLCPP_WARN_STREAM(this->nh_->get_logger(),
-                         "[sim] Invalid rotor_visual_speed_rate hardware parameter: "
-                             << rotor_visual_speed_rate_it->second);
+      RCLCPP_WARN_STREAM(this->nh_->get_logger(), "[sim] Invalid rotor_visual_speed_rate hardware parameter: "
+                                                      << rotor_visual_speed_rate_it->second);
     }
   }
 
@@ -586,8 +584,8 @@ bool AerialRobotHwSim::initSim(rclcpp::Node::SharedPtr &model_nh, std::map<std::
         {
           if (this->dataPtr->joints_[j].sim_child_link == sim::kNullEntity)
           {
-            RCLCPP_WARN_STREAM(this->nh_->get_logger(), "[sim] Rotor joint " << joint_name
-                                                                             << " has no child link for thrust");
+            RCLCPP_WARN_STREAM(this->nh_->get_logger(),
+                               "[sim] Rotor joint " << joint_name << " has no child link for thrust");
           }
           else
           {
@@ -1096,9 +1094,8 @@ hardware_interface::return_type AerialRobotHwSim::write(const rclcpp::Time &sim_
           sim::Link rotor_link(this->dataPtr->joints_[i].sim_child_link);
           const auto rotor_pose = sim::worldPose(this->dataPtr->joints_[i].sim_child_link, *this->dataPtr->ecm);
           const auto thrust_axis = rotor_pose.Rot().RotateVector(ignition::math::Vector3d::UnitZ);
-          const auto yaw_drag_torque =
-              thrust_axis * (thrust * this->dataPtr->joints_[i].rotor_direction *
-                             this->dataPtr->joints_[i].m_f_rate);
+          const auto yaw_drag_torque = thrust_axis * (thrust * this->dataPtr->joints_[i].rotor_direction *
+                                                      this->dataPtr->joints_[i].m_f_rate);
 
           if (this->dataPtr->joints_[i].sim_parent_link != sim::kNullEntity)
           {
@@ -1111,8 +1108,7 @@ hardware_interface::return_type AerialRobotHwSim::write(const rclcpp::Time &sim_
           }
           else
           {
-            rotor_link.AddWorldWrench(
-                *this->dataPtr->ecm, thrust_axis * thrust, yaw_drag_torque);
+            rotor_link.AddWorldWrench(*this->dataPtr->ecm, thrust_axis * thrust, yaw_drag_torque);
           }
         }
 
@@ -1151,7 +1147,8 @@ hardware_interface::return_type AerialRobotHwSim::write(const rclcpp::Time &sim_
   for (const auto &rotor_parent_wrench : rotor_parent_wrenches)
   {
     sim::Link parent_link(rotor_parent_wrench.first);
-    parent_link.AddWorldWrench(*this->dataPtr->ecm, rotor_parent_wrench.second.first, rotor_parent_wrench.second.second);
+    parent_link.AddWorldWrench(*this->dataPtr->ecm, rotor_parent_wrench.second.first,
+                               rotor_parent_wrench.second.second);
   }
 
   // Set values of all mimic joints with respect to mimicked joint

--- a/aerial_robot_simulation/src/aerial_robot_hw_sim.cpp
+++ b/aerial_robot_simulation/src/aerial_robot_hw_sim.cpp
@@ -44,6 +44,7 @@ magnetometer and pseudo-motion capture are incorporated.
 
 #include <ignition/gazebo/Joint.hh>
 #include <ignition/gazebo/Link.hh>
+#include <ignition/gazebo/Util.hh>
 #include <ignition/gazebo/components/AngularVelocity.hh>
 #include <ignition/gazebo/components/Imu.hh>
 #include <ignition/gazebo/components/JointForce.hh>
@@ -106,6 +107,9 @@ struct jointData
 
   /// \brief handles to the joints from within Gazebo
   sim::Entity sim_joint{ sim::kNullEntity };
+
+  /// \brief parent link where rotor yaw drag torque is applied
+  sim::Entity sim_parent_link{ sim::kNullEntity };
 
   /// \brief child link where rotor thrust is applied
   sim::Entity sim_child_link{ sim::kNullEntity };
@@ -363,6 +367,12 @@ bool AerialRobotHwSim::initSim(rclcpp::Node::SharedPtr &model_nh, std::map<std::
     this->dataPtr->joints_[j].sim_joint = simjoint;
 
     sim::Joint joint(simjoint);
+    const auto parent_link_name = joint.ParentLinkName(ecm);
+    if (parent_link_name)
+    {
+      this->dataPtr->joints_[j].sim_parent_link = find_link_by_name(*parent_link_name);
+    }
+
     const auto child_link_name = joint.ChildLinkName(ecm);
     if (child_link_name)
     {
@@ -993,6 +1003,8 @@ hardware_interface::return_type AerialRobotHwSim::perform_command_mode_switch(
 
 hardware_interface::return_type AerialRobotHwSim::write(const rclcpp::Time &sim_time, const rclcpp::Duration &period)
 {
+  std::map<sim::Entity, std::pair<ignition::math::Vector3d, ignition::math::Vector3d>> rotor_parent_wrenches;
+
   for (unsigned int i = 0; i < this->dataPtr->joints_.size(); ++i)
   {
     if (this->dataPtr->joints_[i].sim_joint == sim::kNullEntity)
@@ -1046,17 +1058,26 @@ hardware_interface::return_type AerialRobotHwSim::write(const rclcpp::Time &sim_
         if (this->dataPtr->joints_[i].sim_child_link != sim::kNullEntity)
         {
           sim::Link rotor_link(this->dataPtr->joints_[i].sim_child_link);
-          ignition::math::Vector3d thrust_axis(0.0, 0.0, 1.0);
-          const auto pose = rotor_link.WorldPose(*this->dataPtr->ecm);
-          if (pose)
-          {
-            thrust_axis = pose->Rot().RotateVector(thrust_axis);
-          }
-
-          rotor_link.AddWorldWrench(
-              *this->dataPtr->ecm, thrust_axis * thrust,
+          const auto rotor_pose = sim::worldPose(this->dataPtr->joints_[i].sim_child_link, *this->dataPtr->ecm);
+          const auto thrust_axis = rotor_pose.Rot().RotateVector(ignition::math::Vector3d::UnitZ);
+          const auto yaw_drag_torque =
               thrust_axis * (thrust * this->dataPtr->joints_[i].rotor_direction *
-                             this->dataPtr->joints_[i].m_f_rate));
+                             this->dataPtr->joints_[i].m_f_rate);
+
+          if (this->dataPtr->joints_[i].sim_parent_link != sim::kNullEntity)
+          {
+            const auto parent_pose = sim::worldPose(this->dataPtr->joints_[i].sim_parent_link, *this->dataPtr->ecm);
+            const auto thrust_force = thrust_axis * thrust;
+            const auto thrust_arm = rotor_pose.Pos() - parent_pose.Pos();
+            auto &wrench = rotor_parent_wrenches[this->dataPtr->joints_[i].sim_parent_link];
+            wrench.first += thrust_force;
+            wrench.second += thrust_arm.Cross(thrust_force) + yaw_drag_torque;
+          }
+          else
+          {
+            rotor_link.AddWorldWrench(
+                *this->dataPtr->ecm, thrust_axis * thrust, yaw_drag_torque);
+          }
         }
 
         continue;
@@ -1089,6 +1110,12 @@ hardware_interface::return_type AerialRobotHwSim::write(const rclcpp::Time &sim_
         vel->Data()[0] = target_vel;
       }
     }
+  }
+
+  for (const auto &rotor_parent_wrench : rotor_parent_wrenches)
+  {
+    sim::Link parent_link(rotor_parent_wrench.first);
+    parent_link.AddWorldWrench(*this->dataPtr->ecm, rotor_parent_wrench.second.first, rotor_parent_wrench.second.second);
   }
 
   // Set values of all mimic joints with respect to mimicked joint

--- a/aerial_robot_simulation/src/aerial_robot_hw_sim.cpp
+++ b/aerial_robot_simulation/src/aerial_robot_hw_sim.cpp
@@ -120,6 +120,9 @@ struct jointData
   /// \brief force to yaw torque conversion rate
   double m_f_rate{ 0.0 };
 
+  /// \brief visual joint speed per thrust force [rad/s/N]
+  double rotor_visual_speed_rate{ 1.0 };
+
   /// \brief Control method defined in the URDF for each joint.
   gz_ros2_control::GazeboSimSystemInterface::ControlMethod joint_control_method{
     gz_ros2_control::GazeboSimSystemInterface::NONE
@@ -334,6 +337,24 @@ bool AerialRobotHwSim::initSim(rclcpp::Node::SharedPtr &model_nh, std::map<std::
     RCLCPP_WARN(this->nh_->get_logger(), "[sim] m_f_rate hardware parameter is not set; yaw drag torque is 0");
   }
 
+  double rotor_visual_speed_rate = 1.0;
+  const auto rotor_visual_speed_rate_it = hardware_info.hardware_parameters.find("rotor_visual_speed_rate");
+  if (rotor_visual_speed_rate_it != hardware_info.hardware_parameters.end())
+  {
+    try
+    {
+      rotor_visual_speed_rate = std::stod(rotor_visual_speed_rate_it->second);
+      RCLCPP_INFO_STREAM(this->nh_->get_logger(), "[sim] Loaded rotor_visual_speed_rate: "
+                                                     << rotor_visual_speed_rate);
+    }
+    catch (const std::exception &)
+    {
+      RCLCPP_WARN_STREAM(this->nh_->get_logger(),
+                         "[sim] Invalid rotor_visual_speed_rate hardware parameter: "
+                             << rotor_visual_speed_rate_it->second);
+    }
+  }
+
   auto find_link_by_name = [&ecm](const std::string &link_name)
   {
     sim::Entity result = sim::kNullEntity;
@@ -386,6 +407,7 @@ bool AerialRobotHwSim::initSim(rclcpp::Node::SharedPtr &model_nh, std::map<std::
       this->dataPtr->joints_[j].rotor_direction = axis_z < 0.0 ? -1.0 : 1.0;
     }
     this->dataPtr->joints_[j].m_f_rate = m_f_rate;
+    this->dataPtr->joints_[j].rotor_visual_speed_rate = rotor_visual_speed_rate;
 
     // Create joint position component if one doesn't exist
     if (!ecm.EntityHasComponentType(simjoint, sim::components::JointPosition().TypeId()))
@@ -1054,6 +1076,20 @@ hardware_interface::return_type AerialRobotHwSim::write(const rclcpp::Time &sim_
       {
         const double thrust = std::max(0.0, this->dataPtr->joints_[i].joint_effort_cmd);
         this->dataPtr->joints_[i].joint_effort = thrust;
+
+        const double visual_speed = thrust * this->dataPtr->joints_[i].rotor_visual_speed_rate;
+        this->dataPtr->joints_[i].joint_velocity_cmd = visual_speed;
+        auto vel = this->dataPtr->ecm->Component<sim::components::JointVelocityCmd>(
+            this->dataPtr->joints_[i].sim_joint);
+        if (vel == nullptr)
+        {
+          this->dataPtr->ecm->CreateComponent(this->dataPtr->joints_[i].sim_joint,
+                                              sim::components::JointVelocityCmd({ visual_speed }));
+        }
+        else if (!vel->Data().empty())
+        {
+          vel->Data()[0] = visual_speed;
+        }
 
         if (this->dataPtr->joints_[i].sim_child_link != sim::kNullEntity)
         {

--- a/aerial_robot_simulation/src/aerial_robot_hw_sim.cpp
+++ b/aerial_robot_simulation/src/aerial_robot_hw_sim.cpp
@@ -42,6 +42,8 @@ magnetometer and pseudo-motion capture are incorporated.
 
 #include <ignition/msgs/imu.pb.h>
 
+#include <ignition/gazebo/Joint.hh>
+#include <ignition/gazebo/Link.hh>
 #include <ignition/gazebo/components/AngularVelocity.hh>
 #include <ignition/gazebo/components/Imu.hh>
 #include <ignition/gazebo/components/JointForce.hh>
@@ -61,6 +63,8 @@ magnetometer and pseudo-motion capture are incorporated.
 #include <ignition/gazebo/components/Sensor.hh>
 #include <ignition/math.hh>
 #include <ignition/transport/Node.hh>
+#include <cmath>
+#include <exception>
 #include <limits>
 #include <map>
 #include <memory>
@@ -77,31 +81,45 @@ struct jointData
   std::string name;
 
   /// \brief Current joint position
-  double joint_position;
+  double joint_position{ 0.0 };
 
   /// \brief Current joint velocity
-  double joint_velocity;
+  double joint_velocity{ 0.0 };
 
   /// \brief Current joint effort
-  double joint_effort;
+  double joint_effort{ 0.0 };
 
   /// \brief Current cmd joint position
-  double joint_position_cmd;
+  double joint_position_cmd{ 0.0 };
 
   /// \brief Current cmd joint velocity
-  double joint_velocity_cmd;
+  double joint_velocity_cmd{ 0.0 };
 
   /// \brief Current cmd joint effort
-  double joint_effort_cmd;
+  double joint_effort_cmd{ 0.0 };
 
   /// \brief flag if joint is actuated (has command interfaces) or passive
-  bool is_actuated;
+  bool is_actuated{ false };
+
+  /// \brief flag if this joint command represents rotor thrust
+  bool is_rotor{ false };
 
   /// \brief handles to the joints from within Gazebo
-  sim::Entity sim_joint;
+  sim::Entity sim_joint{ sim::kNullEntity };
+
+  /// \brief child link where rotor thrust is applied
+  sim::Entity sim_child_link{ sim::kNullEntity };
+
+  /// \brief rotor spin direction, taken from the joint axis z sign
+  double rotor_direction{ 1.0 };
+
+  /// \brief force to yaw torque conversion rate
+  double m_f_rate{ 0.0 };
 
   /// \brief Control method defined in the URDF for each joint.
-  gz_ros2_control::GazeboSimSystemInterface::ControlMethod joint_control_method;
+  gz_ros2_control::GazeboSimSystemInterface::ControlMethod joint_control_method{
+    gz_ros2_control::GazeboSimSystemInterface::NONE
+  };
 };
 
 struct MimicJoint
@@ -293,6 +311,41 @@ bool AerialRobotHwSim::initSim(rclcpp::Node::SharedPtr &model_nh, std::map<std::
     return false;
   }
 
+  double m_f_rate = 0.0;
+  const auto m_f_rate_it = hardware_info.hardware_parameters.find("m_f_rate");
+  if (m_f_rate_it != hardware_info.hardware_parameters.end())
+  {
+    try
+    {
+      m_f_rate = std::stod(m_f_rate_it->second);
+      RCLCPP_INFO_STREAM(this->nh_->get_logger(), "[sim] Loaded m_f_rate: " << m_f_rate);
+    }
+    catch (const std::exception &)
+    {
+      RCLCPP_WARN_STREAM(this->nh_->get_logger(), "[sim] Invalid m_f_rate hardware parameter: " << m_f_rate_it->second);
+    }
+  }
+  else
+  {
+    RCLCPP_WARN(this->nh_->get_logger(), "[sim] m_f_rate hardware parameter is not set; yaw drag torque is 0");
+  }
+
+  auto find_link_by_name = [&ecm](const std::string &link_name)
+  {
+    sim::Entity result = sim::kNullEntity;
+    ecm.Each<sim::components::Link, sim::components::Name>(
+        [&](const sim::Entity &entity, const sim::components::Link *, const sim::components::Name *name) -> bool
+        {
+          if (name->Data() == link_name)
+          {
+            result = entity;
+            return false;
+          }
+          return true;
+        });
+    return result;
+  };
+
   for (unsigned int j = 0; j < this->dataPtr->n_dof_; j++)
   {
     auto &joint_info = hardware_info.joints[j];
@@ -308,6 +361,21 @@ bool AerialRobotHwSim::initSim(rclcpp::Node::SharedPtr &model_nh, std::map<std::
 
     sim::Entity simjoint = enableJoints[joint_name];
     this->dataPtr->joints_[j].sim_joint = simjoint;
+
+    sim::Joint joint(simjoint);
+    const auto child_link_name = joint.ChildLinkName(ecm);
+    if (child_link_name)
+    {
+      this->dataPtr->joints_[j].sim_child_link = find_link_by_name(*child_link_name);
+    }
+
+    const auto joint_axes = joint.Axis(ecm);
+    if (joint_axes && !joint_axes->empty())
+    {
+      const double axis_z = joint_axes->front().Xyz().Z();
+      this->dataPtr->joints_[j].rotor_direction = axis_z < 0.0 ? -1.0 : 1.0;
+    }
+    this->dataPtr->joints_[j].m_f_rate = m_f_rate;
 
     // Create joint position component if one doesn't exist
     if (!ecm.EntityHasComponentType(simjoint, sim::components::JointPosition().TypeId()))
@@ -478,9 +546,22 @@ bool AerialRobotHwSim::initSim(rclcpp::Node::SharedPtr &model_nh, std::map<std::
       else if (joint_info.command_interfaces[i].name == "effort")
       {
         this->dataPtr->joints_[j].joint_control_method |= EFFORT;
+        this->dataPtr->joints_[j].is_rotor = joint_name.rfind("rotor", 0) == 0;
         RCLCPP_INFO_STREAM(this->nh_->get_logger(), "\t\t effort");
         this->dataPtr->command_interfaces_.emplace_back(joint_name + suffix, hardware_interface::HW_IF_EFFORT,
                                                         &this->dataPtr->joints_[j].joint_effort_cmd);
+        if (this->dataPtr->joints_[j].is_rotor)
+        {
+          if (this->dataPtr->joints_[j].sim_child_link == sim::kNullEntity)
+          {
+            RCLCPP_WARN_STREAM(this->nh_->get_logger(), "[sim] Rotor joint " << joint_name
+                                                                             << " has no child link for thrust");
+          }
+          else
+          {
+            RCLCPP_INFO_STREAM(this->nh_->get_logger(), "[sim] Rotor thrust command registered for " << joint_name);
+          }
+        }
         if (!std::isnan(initial_effort))
         {
           this->dataPtr->joints_[j].joint_effort_cmd = initial_effort;
@@ -957,6 +1038,30 @@ hardware_interface::return_type AerialRobotHwSim::write(const rclcpp::Time &sim_
     }
     else if (this->dataPtr->joints_[i].joint_control_method & EFFORT)
     {
+      if (this->dataPtr->joints_[i].is_rotor)
+      {
+        const double thrust = std::max(0.0, this->dataPtr->joints_[i].joint_effort_cmd);
+        this->dataPtr->joints_[i].joint_effort = thrust;
+
+        if (this->dataPtr->joints_[i].sim_child_link != sim::kNullEntity)
+        {
+          sim::Link rotor_link(this->dataPtr->joints_[i].sim_child_link);
+          ignition::math::Vector3d thrust_axis(0.0, 0.0, 1.0);
+          const auto pose = rotor_link.WorldPose(*this->dataPtr->ecm);
+          if (pose)
+          {
+            thrust_axis = pose->Rot().RotateVector(thrust_axis);
+          }
+
+          rotor_link.AddWorldWrench(
+              *this->dataPtr->ecm, thrust_axis * thrust,
+              thrust_axis * (thrust * this->dataPtr->joints_[i].rotor_direction *
+                             this->dataPtr->joints_[i].m_f_rate));
+        }
+
+        continue;
+      }
+
       if (!this->dataPtr->ecm->Component<sim::components::JointForceCmd>(this->dataPtr->joints_[i].sim_joint))
       {
         this->dataPtr->ecm->CreateComponent(this->dataPtr->joints_[i].sim_joint, sim::components::JointForceCmd({ 0 }));

--- a/aerial_robot_simulation/src/mujoco_attitude_controller_node.cpp
+++ b/aerial_robot_simulation/src/mujoco_attitude_controller_node.cpp
@@ -1,0 +1,189 @@
+// -*- mode: c++ -*-
+/*
+ * Software License Agreement (BSD-3 License)
+ *
+ * Copyright (c) 2026, DRAGON Laboratory, The University of Tokyo
+ * All rights reserved.
+ */
+
+#include "aerial_robot_simulation/spinal_interface.h"
+
+#include <flight_control/simulation/flight_control_ros_module.h>
+#include <thruster/simulation/thruster_ros_module.h>
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <lifecycle_msgs/msg/state.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
+#include <sensor_msgs/msg/magnetic_field.hpp>
+
+namespace aerial_robot_simulation {
+
+class MujocoAttitudeControllerNode {
+public:
+  explicit MujocoAttitudeControllerNode(
+      const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> &node)
+      : node_(node) {
+    node_->declare_parameter<double>("update_rate", 1000.0);
+    node_->declare_parameter<std::vector<std::string>>(
+        "rotor_joints", {"rotor1", "rotor2", "rotor3", "rotor4"});
+    node_->declare_parameter<bool>("use_ground_truth", true);
+
+    rotor_joints_ = node_->get_parameter("rotor_joints").as_string_array();
+    if (rotor_joints_.empty()) {
+      rotor_joints_ = {"rotor1", "rotor2", "rotor3", "rotor4"};
+    }
+
+    spinal_iface_.init(node_);
+    spinal_iface_.useGroundTruth(
+        node_->get_parameter("use_ground_truth").as_bool());
+
+    thruster_ros_mod_.init(node_);
+    flight_control_ros_mod_.init(
+        node_, spinal_iface_.getEstimatorPtr()->getEstimator(),
+        thruster_ros_mod_.getThrusterManager());
+
+    spinal_iface_.getEstimatorPtr()->getImuPub()->on_activate();
+    flight_control_ros_mod_.activate();
+    thruster_ros_mod_.activate();
+
+    rotor_force_pub_ = node_->create_publisher<sensor_msgs::msg::JointState>(
+        "mujoco/rotor_forces", rclcpp::QoS(1));
+
+    const auto sensor_qos = rclcpp::SensorDataQoS();
+    imu_sub_ = node_->create_subscription<sensor_msgs::msg::Imu>(
+        "mujoco/imu", sensor_qos,
+        [this](const sensor_msgs::msg::Imu::SharedPtr msg) {
+          latest_imu_ = *msg;
+          have_imu_ = true;
+        });
+
+    mag_sub_ = node_->create_subscription<sensor_msgs::msg::MagneticField>(
+        "mujoco/mag", sensor_qos,
+        [this](const sensor_msgs::msg::MagneticField::SharedPtr msg) {
+          latest_mag_ = *msg;
+          have_mag_ = true;
+        });
+
+    ground_truth_sub_ = node_->create_subscription<nav_msgs::msg::Odometry>(
+        "ground_truth", rclcpp::QoS(1),
+        [this](const nav_msgs::msg::Odometry::SharedPtr msg) {
+          latest_ground_truth_ = *msg;
+          have_ground_truth_ = true;
+        });
+
+    const double update_rate =
+        std::max(1.0, node_->get_parameter("update_rate").as_double());
+    const auto period = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::duration<double>(1.0 / update_rate));
+    update_timer_ = node_->create_wall_timer(period, [this]() { update(); });
+
+    RCLCPP_INFO(
+        node_->get_logger(),
+        "[mujoco] attitude controller node started with %.1f Hz update rate",
+        update_rate);
+  }
+
+private:
+  void update() {
+    if (!have_imu_) {
+      return;
+    }
+
+    spinal_iface_.onGround(false);
+    spinal_iface_.setImuValue(
+        latest_imu_.linear_acceleration.x, latest_imu_.linear_acceleration.y,
+        latest_imu_.linear_acceleration.z, latest_imu_.angular_velocity.x,
+        latest_imu_.angular_velocity.y, latest_imu_.angular_velocity.z);
+
+    if (have_mag_) {
+      spinal_iface_.setMagValue(latest_mag_.magnetic_field.x,
+                                latest_mag_.magnetic_field.y,
+                                latest_mag_.magnetic_field.z);
+    }
+
+    if (have_ground_truth_) {
+      spinal_iface_.setGroundTruthStates(
+          latest_ground_truth_.pose.pose.orientation.x,
+          latest_ground_truth_.pose.pose.orientation.y,
+          latest_ground_truth_.pose.pose.orientation.z,
+          latest_ground_truth_.pose.pose.orientation.w,
+          latest_ground_truth_.twist.twist.angular.x,
+          latest_ground_truth_.twist.twist.angular.y,
+          latest_ground_truth_.twist.twist.angular.z);
+    }
+
+    spinal_iface_.stateEstimate();
+
+    flight_control_ros_mod_.update();
+    thruster_ros_mod_.sendCommand();
+    publishRotorForces_();
+    flight_control_ros_mod_.publish();
+    thruster_ros_mod_.publish();
+  }
+
+  void publishRotorForces_() {
+    ThrusterManager *thruster = thruster_ros_mod_.getThrusterManager();
+    if (thruster == nullptr || !rotor_force_pub_) {
+      return;
+    }
+
+    sensor_msgs::msg::JointState msg;
+    msg.header.stamp = node_->now();
+
+    const size_t n =
+        std::min(rotor_joints_.size(), static_cast<size_t>(MAX_THRUSTER_NUM));
+    msg.name.resize(n);
+    msg.effort.resize(n);
+    for (size_t i = 0; i < n; ++i) {
+      msg.name[i] = rotor_joints_[i];
+      msg.effort[i] = static_cast<double>(
+          thruster->getTargetThrust(static_cast<uint8_t>(i)));
+    }
+    rotor_force_pub_->publish(msg);
+  }
+
+  std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node_;
+
+  hardware_interface::SpinalInterface spinal_iface_;
+  ThrusterRosModule thruster_ros_mod_;
+  FlightControlRosModule flight_control_ros_mod_;
+
+  std::vector<std::string> rotor_joints_;
+
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr imu_sub_;
+  rclcpp::Subscription<sensor_msgs::msg::MagneticField>::SharedPtr mag_sub_;
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr ground_truth_sub_;
+  rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr rotor_force_pub_;
+  rclcpp::TimerBase::SharedPtr update_timer_;
+
+  sensor_msgs::msg::Imu latest_imu_;
+  sensor_msgs::msg::MagneticField latest_mag_;
+  nav_msgs::msg::Odometry latest_ground_truth_;
+  bool have_imu_{false};
+  bool have_mag_{false};
+  bool have_ground_truth_{false};
+};
+
+} // namespace aerial_robot_simulation
+
+int main(int argc, char **argv) {
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>(
+      "mujoco_attitude_controller");
+  auto controller =
+      std::make_shared<aerial_robot_simulation::MujocoAttitudeControllerNode>(
+          node);
+  (void)controller;
+  rclcpp::spin(node->get_node_base_interface());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/aerial_robot_simulation/src/simulation_attitude_controller.cpp
+++ b/aerial_robot_simulation/src/simulation_attitude_controller.cpp
@@ -102,10 +102,8 @@ controller_interface::CallbackReturn SimulationAttitudeController::on_configure(
   spinal_iface_.useGroundTruth(true);
 
   thruster_ros_mod_.init(get_node());
-  flight_control_ros_mod_.init(
-    get_node(),
-    spinal_iface_.getEstimatorPtr()->getEstimator(),
-    thruster_ros_mod_.getThrusterManager());
+  flight_control_ros_mod_.init(get_node(), spinal_iface_.getEstimatorPtr()->getEstimator(),
+                               thruster_ros_mod_.getThrusterManager());
 
   RCLCPP_INFO(get_node()->get_logger(), "[sim] SimulationAttitudeController: on_configure");
   return controller_interface::CallbackReturn::SUCCESS;
@@ -128,9 +126,7 @@ controller_interface::CallbackReturn SimulationAttitudeController::on_deactivate
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
-controller_interface::return_type SimulationAttitudeController::update(
-  const rclcpp::Time &,
-  const rclcpp::Duration &)
+controller_interface::return_type SimulationAttitudeController::update(const rclcpp::Time &, const rclcpp::Duration &)
 {
   if (get_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
   {
@@ -172,7 +168,7 @@ controller_interface::return_type SimulationAttitudeController::update(
 
 void SimulationAttitudeController::writeRotorCommands_()
 {
-  ThrusterManager* thruster = thruster_ros_mod_.getThrusterManager();
+  ThrusterManager *thruster = thruster_ros_mod_.getThrusterManager();
   const size_t n = std::min(command_interfaces_.size(), static_cast<size_t>(MAX_THRUSTER_NUM));
   for (size_t i = 0; i < n; ++i)
   {

--- a/aerial_robot_simulation/src/simulation_attitude_controller.cpp
+++ b/aerial_robot_simulation/src/simulation_attitude_controller.cpp
@@ -99,6 +99,8 @@ controller_interface::InterfaceConfiguration SimulationAttitudeController::state
 
 controller_interface::CallbackReturn SimulationAttitudeController::on_configure(const rclcpp_lifecycle::State &)
 {
+  spinal_iface_.useGroundTruth(true);
+
   thruster_ros_mod_.init(get_node());
   flight_control_ros_mod_.init(
     get_node(),
@@ -137,6 +139,11 @@ controller_interface::return_type SimulationAttitudeController::update(
 
   spinal_iface_.onGround(false);
 
+  const double q_x = state_interfaces_[0].get_value();
+  const double q_y = state_interfaces_[1].get_value();
+  const double q_z = state_interfaces_[2].get_value();
+  const double q_w = state_interfaces_[3].get_value();
+
   const double ang_x = state_interfaces_[4].get_value();
   const double ang_y = state_interfaces_[5].get_value();
   const double ang_z = state_interfaces_[6].get_value();
@@ -151,6 +158,7 @@ controller_interface::return_type SimulationAttitudeController::update(
 
   spinal_iface_.setImuValue(acc_x, acc_y, acc_z, ang_x, ang_y, ang_z);
   spinal_iface_.setMagValue(mag_x, mag_y, mag_z);
+  spinal_iface_.setGroundTruthStates(q_x, q_y, q_z, q_w, ang_x, ang_y, ang_z);
   spinal_iface_.stateEstimate();
 
   flight_control_ros_mod_.update();

--- a/aerial_robot_simulation/src/simulation_attitude_controller.cpp
+++ b/aerial_robot_simulation/src/simulation_attitude_controller.cpp
@@ -34,11 +34,15 @@
  */
 #include "aerial_robot_simulation/simulation_attitude_controller.h"
 
+#include <algorithm>
+#include <array>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "controller_interface/controller_interface.hpp"
 #include "hardware_interface/handle.hpp"
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "pluginlib/class_list_macros.hpp"
 #include "rclcpp/rclcpp.hpp"
 
@@ -48,6 +52,7 @@ controller_interface::CallbackReturn SimulationAttitudeController::on_init()
 {
   auto_declare<std::string>("imu", "spinal_imu");
   auto_declare<std::string>("mag", "spinal_mag");
+  auto_declare<std::vector<std::string>>("rotor_joints", { "rotor1", "rotor2", "rotor3", "rotor4" });
   spinal_iface_.init(get_node());
   return controller_interface::CallbackReturn::SUCCESS;
 }
@@ -56,6 +61,11 @@ controller_interface::InterfaceConfiguration SimulationAttitudeController::comma
 {
   controller_interface::InterfaceConfiguration config;
   config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
+  const std::vector<std::string> rotor_joints = get_node()->get_parameter("rotor_joints").as_string_array();
+  for (const auto &joint : rotor_joints)
+  {
+    config.names.push_back(joint + "/" + hardware_interface::HW_IF_EFFORT);
+  }
   return config;
 }
 
@@ -64,7 +74,6 @@ controller_interface::InterfaceConfiguration SimulationAttitudeController::state
   controller_interface::InterfaceConfiguration config;
   config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
 
-  // IMU sensor value
   static const std::array<std::string, 10> imu_ifaces = { "orientation.x",         "orientation.y",
                                                           "orientation.z",         "orientation.w",
                                                           "angular_velocity.x",    "angular_velocity.y",
@@ -77,7 +86,6 @@ controller_interface::InterfaceConfiguration SimulationAttitudeController::state
     config.names.push_back(imu + "/" + iface);
   }
 
-  // Mag sensor value
   static const std::array<std::string, 3> mag_ifaces = { "field_tesla.x", "field_tesla.y", "field_tesla.z" };
 
   const std::string mag = get_node()->get_parameter("mag").as_string();
@@ -91,27 +99,36 @@ controller_interface::InterfaceConfiguration SimulationAttitudeController::state
 
 controller_interface::CallbackReturn SimulationAttitudeController::on_configure(const rclcpp_lifecycle::State &)
 {
+  thruster_ros_mod_.init(get_node());
+  flight_control_ros_mod_.init(
+    get_node(),
+    spinal_iface_.getEstimatorPtr()->getEstimator(),
+    thruster_ros_mod_.getThrusterManager());
+
   RCLCPP_INFO(get_node()->get_logger(), "[sim] SimulationAttitudeController: on_configure");
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
 controller_interface::CallbackReturn SimulationAttitudeController::on_activate(const rclcpp_lifecycle::State &)
 {
-  // Activate publishers
   spinal_iface_.getEstimatorPtr()->getImuPub()->on_activate();
+  flight_control_ros_mod_.activate();
+  thruster_ros_mod_.activate();
   RCLCPP_INFO(get_node()->get_logger(), "[sim] SimulationAttitudeController: on_activate");
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
 controller_interface::CallbackReturn SimulationAttitudeController::on_deactivate(const rclcpp_lifecycle::State &)
 {
+  flight_control_ros_mod_.deactivate();
+  thruster_ros_mod_.deactivate();
   RCLCPP_INFO(get_node()->get_logger(), "[sim] SimulationAttitudeController: on_deactivate");
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
-controller_interface::return_type SimulationAttitudeController::update(const rclcpp::Time & /* Time*/,
-                                                                       const rclcpp::Duration & /* Period*/
-)
+controller_interface::return_type SimulationAttitudeController::update(
+  const rclcpp::Time &,
+  const rclcpp::Duration &)
 {
   if (get_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
   {
@@ -120,25 +137,39 @@ controller_interface::return_type SimulationAttitudeController::update(const rcl
 
   spinal_iface_.onGround(false);
 
-  // Angular velocity
-  double ang_x = state_interfaces_[4].get_value();
-  double ang_y = state_interfaces_[5].get_value();
-  double ang_z = state_interfaces_[6].get_value();
+  const double ang_x = state_interfaces_[4].get_value();
+  const double ang_y = state_interfaces_[5].get_value();
+  const double ang_z = state_interfaces_[6].get_value();
 
-  // Linear acceleration
-  double acc_x = state_interfaces_[7].get_value();
-  double acc_y = state_interfaces_[8].get_value();
-  double acc_z = state_interfaces_[9].get_value();
+  const double acc_x = state_interfaces_[7].get_value();
+  const double acc_y = state_interfaces_[8].get_value();
+  const double acc_z = state_interfaces_[9].get_value();
 
-  // Mag value
-  double mag_x = state_interfaces_[10].get_value();
-  double mag_y = state_interfaces_[11].get_value();
-  double mag_z = state_interfaces_[12].get_value();
+  const double mag_x = state_interfaces_[10].get_value();
+  const double mag_y = state_interfaces_[11].get_value();
+  const double mag_z = state_interfaces_[12].get_value();
 
   spinal_iface_.setImuValue(acc_x, acc_y, acc_z, ang_x, ang_y, ang_z);
   spinal_iface_.setMagValue(mag_x, mag_y, mag_z);
   spinal_iface_.stateEstimate();
+
+  flight_control_ros_mod_.update();
+  thruster_ros_mod_.sendCommand();
+  writeRotorCommands_();
+  flight_control_ros_mod_.publish();
+  thruster_ros_mod_.publish();
+
   return controller_interface::return_type::OK;
+}
+
+void SimulationAttitudeController::writeRotorCommands_()
+{
+  ThrusterManager* thruster = thruster_ros_mod_.getThrusterManager();
+  const size_t n = std::min(command_interfaces_.size(), static_cast<size_t>(MAX_THRUSTER_NUM));
+  for (size_t i = 0; i < n; ++i)
+  {
+    command_interfaces_[i].set_value(static_cast<double>(thruster->getTargetThrust(static_cast<uint8_t>(i))));
+  }
 }
 
 }

--- a/dependencies/rosdep/mujoco.yaml
+++ b/dependencies/rosdep/mujoco.yaml
@@ -1,0 +1,5 @@
+python3-mujoco:
+  ubuntu:
+    pip:
+      packages:
+        - mujoco

--- a/robots/mini_quadrotor/config/ControllerConfig.yaml
+++ b/robots/mini_quadrotor/config/ControllerConfig.yaml
@@ -12,22 +12,24 @@
 
       # NOTE: Always define parameters as double (5.0) instead of int (5)
       xy:
-        p_gain: 5.0
-        i_gain: 0.05
-        d_gain: 5.0
-        limit_sum: 3.0
-        limit_p: 3.0
-        limit_i: 1.5
-        limit_d: 3.0
+        p_gain: 1.0
+        i_gain: 0.0
+        d_gain: 1.5
+        limit_sum: 1.5
+        limit_p: 1.5
+        limit_i: 0.0
+        limit_d: 1.5
 
-      # roll_pitch:
-      #   p_gain: 0.0
-      #   i_gain: 0.0
-      #   d_gain: 0.0
-      #   limit_sum: 0.0
-      #   limit_p: 0.0
-      #   limit_i: 0.0
-      #   limit_d: 0.0
+      roll_pitch:
+        p_gain: 8.0
+        i_gain: 0.0
+        d_gain: 3.0
+        limit_sum: 4.0
+        limit_p: 3.0
+        limit_i: 0.0
+        limit_d: 2.0
+        limit_err_p: 0.6
+        start_integration_height: 0.3
 
       z:
         p_gain: 5.0
@@ -42,9 +44,9 @@
         force_landing_descending_rate: -0.6
 
       yaw:
-        # p_gain: 0.0
-        # i_gain: 0.0
-        # d_gain: 0.0
+        p_gain: 4.0
+        i_gain: 0.0
+        d_gain: 2.0
         limit_sum: 6.0  # N for clamping thrust force
         limit_p: 4.0
         limit_i: 4.0
@@ -75,4 +77,3 @@
 
         trans_constraint_weight: 100.0
         att_control_weight: 1.0
-

--- a/robots/mini_quadrotor/config/MotorInfo.yaml
+++ b/robots/mini_quadrotor/config/MotorInfo.yaml
@@ -5,6 +5,7 @@
                 max_pwm: 0.975 # 1950 [ms]
                 min_thrust: 0.0 # [N]
                 force_landing_thrust: 1.0 # [N]
+                m_f_rate: -0.011 # drag torque rate
                 pwm_conversion_mode: 1 # Polynominal Mode
                 vel_ref_num: 2
                 ref1:
@@ -23,4 +24,3 @@
                         polynominal2: -101.84075291  # -1.0184075291 x10^2
                         polynominal1:  81.582961230  # 8.1582961230 x10
                         polynominal0:  56.9010618089 # 56.9010618089 x1
-

--- a/robots/mini_quadrotor/config/Simulation.yaml
+++ b/robots/mini_quadrotor/config/Simulation.yaml
@@ -15,6 +15,11 @@
   ros__parameters:
     imu: "spinal_imu"
     mag: "spinal_mag"
+    rotor_joints:
+      - rotor1
+      - rotor2
+      - rotor3
+      - rotor4
 
 /**/sim_param_server:
   ros__parameters:

--- a/robots/mini_quadrotor/config/Simulation.yaml
+++ b/robots/mini_quadrotor/config/Simulation.yaml
@@ -21,6 +21,36 @@
       - rotor3
       - rotor4
 
+/**/mujoco_attitude_controller:
+  ros__parameters:
+    update_rate: 1000.0
+    use_ground_truth: true
+    rotor_joints:
+      - rotor1
+      - rotor2
+      - rotor3
+      - rotor4
+
+/**/mujoco_bridge:
+  ros__parameters:
+    step_rate: 1000.0
+    render_rate: 60.0
+    rotor_joints:
+      - rotor1
+      - rotor2
+      - rotor3
+      - rotor4
+
+    ground_truth_pub_rate: 0.01
+    ground_truth_pos_noise: 0.001
+    ground_truth_vel_noise: 0.005
+    ground_truth_rot_noise: 0.001
+    ground_truth_angular_noise: 0.005
+
+    mocap_pub_rate: 0.01
+    mocap_pos_noise: 0.001
+    mocap_rot_noise: 0.001
+
 /**/sim_param_server:
   ros__parameters:
 

--- a/robots/mini_quadrotor/launch/bringup_launch.py
+++ b/robots/mini_quadrotor/launch/bringup_launch.py
@@ -35,6 +35,7 @@ _ARGS = [
     ("spawn_y",             "0.0",              "Gazebo spawn Y position [m] (sim only)"),
     ("spawn_z",             "0.5",              "Gazebo spawn Z position [m] (sim only)"),
     ("robot_model_rviz",    "rviz_config.rviz", "RViz config filename (resolved inside robot_model pkg/config/)"),
+    ("debug_core",          "false",            "Run aerial_robot_core under gdb", ["true", "false"]),
 ]
 # fmt: on
 
@@ -77,10 +78,12 @@ def generate_launch_description():
     spawn_y = LaunchConfiguration("spawn_y")
     spawn_z = LaunchConfiguration("spawn_z")
     robot_model_rviz = LaunchConfiguration("robot_model_rviz")
+    debug_core = LaunchConfiguration("debug_core")
 
     active_estimation_mode = PythonExpression(
         ["int('", sim_estimation_mode, "') if '", sim, "' == 'true' else int('", estimation_mode, "')"]
     )
+    core_prefix = PythonExpression(["'gdb -ex run --args' if '", debug_core, "' == 'true' else ''"])
 
     # ------------------------------------------------------------------
     # 2.  Derived paths
@@ -114,6 +117,14 @@ def generate_launch_description():
             FindPackageShare(robot_model_pkg),
             "config",
             "NavigationConfig.yaml",
+        ]
+    )
+
+    common_control_param_path = PathJoinSubstitution(
+        [
+            FindPackageShare("aerial_robot_control"),
+            "config",
+            "PID.yaml",
         ]
     )
 
@@ -184,16 +195,23 @@ def generate_launch_description():
         executable="aerial_robot_core_node",
         name="aerial_robot_core",
         namespace=robot_ns,
-        prefix=["gdb -ex run --args"],
+        prefix=core_prefix,
         parameters=[
             {
                 "main_rate": main_rate,
+                "warn_main_rate": ParameterValue(
+                    PythonExpression(["False if '", sim, "' == 'true' else True"]), value_type=bool
+                ),
+                "main_rate_warn_tolerance": ParameterValue(
+                    PythonExpression(["0.5 if '", sim, "' == 'true' else 0.2"]), value_type=float
+                ),
                 "estimation.mode": active_estimation_mode,
                 "use_sim_time": sim,
             },
             robot_description_param,
             robot_model_param_path,
             state_estimation_path,
+            common_control_param_path,
             control_param_path,
             navigation_param_path,
             motor_info_param_path,

--- a/robots/mini_quadrotor/launch/bringup_launch.py
+++ b/robots/mini_quadrotor/launch/bringup_launch.py
@@ -29,11 +29,14 @@ _ARGS = [
     ("estimation_mode",     "0",                "Estimator mode on real machine: 0=egomotion, 1=experiment, 2=ground-truth", ["0", "1", "2"]),
     ("model_options",       "",                 "Extra xacro arguments passed verbatim to xacro"),
     ("headless",            "true",             "Run without GUI", ["true", "false"]),
-    ("sim",                 "false",            "Launch Gazebo simulation", ["true", "false"]),
+    ("sim",                 "false",            "Launch simulation", ["true", "false"]),
+    ("simulator",           "gazebo",           "Simulator backend used when sim:=true", ["gazebo", "mujoco"]),
     ("sim_estimation_mode", "2",                "Estimator mode in simulation: 0=egomotion, 1=experiment, 2=ground-truth", ["0", "1", "2"]),
-    ("spawn_x",             "0.0",              "Gazebo spawn X position [m] (sim only)"),
-    ("spawn_y",             "0.0",              "Gazebo spawn Y position [m] (sim only)"),
-    ("spawn_z",             "0.5",              "Gazebo spawn Z position [m] (sim only)"),
+    ("spawn_x",             "0.0",              "Simulation spawn X position [m] (sim only)"),
+    ("spawn_y",             "0.0",              "Simulation spawn Y position [m] (sim only)"),
+    ("spawn_z",             "0.5",              "Simulation spawn Z position [m] (sim only)"),
+    ("mujoco_model",        "",                 "MuJoCo MJCF/XML model path. Empty or missing path generates XML from URDF/Xacro"),
+    ("viewer_font_scale",   "100",              "MuJoCo viewer UI font scale percent; set 0 to keep MuJoCo default"),
     ("robot_model_rviz",    "rviz_config.rviz", "RViz config filename (resolved inside robot_model pkg/config/)"),
     ("debug_core",          "false",            "Run aerial_robot_core under gdb", ["true", "false"]),
 ]
@@ -73,12 +76,18 @@ def generate_launch_description():
     model_options = LaunchConfiguration("model_options")
     headless = LaunchConfiguration("headless")
     sim = LaunchConfiguration("sim")
+    simulator = LaunchConfiguration("simulator")
     sim_estimation_mode = LaunchConfiguration("sim_estimation_mode")
     spawn_x = LaunchConfiguration("spawn_x")
     spawn_y = LaunchConfiguration("spawn_y")
     spawn_z = LaunchConfiguration("spawn_z")
+    mujoco_model = LaunchConfiguration("mujoco_model")
+    viewer_font_scale = LaunchConfiguration("viewer_font_scale")
     robot_model_rviz = LaunchConfiguration("robot_model_rviz")
     debug_core = LaunchConfiguration("debug_core")
+
+    sim_is_gazebo = PythonExpression(["('", sim, "' == 'true') and ('", simulator, "' == 'gazebo')"])
+    sim_is_mujoco = PythonExpression(["('", sim, "' == 'true') and ('", simulator, "' == 'mujoco')"])
 
     active_estimation_mode = PythonExpression(
         ["int('", sim_estimation_mode, "') if '", sim, "' == 'true' else int('", estimation_mode, "')"]
@@ -152,7 +161,9 @@ def generate_launch_description():
         ]
     )
 
-    xacro_filename = PythonExpression(["'robot.gazebo.xacro' if '", sim, "' == 'true' else 'robot.urdf.xacro'"])
+    xacro_filename = PythonExpression(
+        ["'robot.gazebo.xacro' if ('", sim, "' == 'true' and '", simulator, "' == 'gazebo') else 'robot.urdf.xacro'"]
+    )
 
     xacro_path = PathJoinSubstitution(
         [
@@ -206,6 +217,7 @@ def generate_launch_description():
                     PythonExpression(["0.5 if '", sim, "' == 'true' else 0.2"]), value_type=float
                 ),
                 "estimation.mode": active_estimation_mode,
+                "robot_model_fixed": ParameterValue(sim_is_mujoco, value_type=bool),
                 "use_sim_time": sim,
             },
             robot_description_param,
@@ -230,6 +242,7 @@ def generate_launch_description():
             servo_param_path,
             {
                 "sim": sim,
+                "use_mujoco": ParameterValue(sim_is_mujoco, value_type=bool),
             },
         ],
         output="screen",
@@ -247,7 +260,7 @@ def generate_launch_description():
             "--param-file",
             servo_param_path,
         ],
-        condition=IfCondition(sim),
+        condition=IfCondition(sim_is_gazebo),
         output="screen",
     )
 
@@ -278,8 +291,7 @@ def generate_launch_description():
         }.items(),
     )
 
-    # Gazebo simulation
-    sim_launch = IncludeLaunchDescription(
+    gazebo_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             PathJoinSubstitution(
                 [
@@ -297,7 +309,32 @@ def generate_launch_description():
             "spawn_y": spawn_y,
             "spawn_z": spawn_z,
         }.items(),
-        condition=IfCondition(sim),
+        condition=IfCondition(sim_is_gazebo),
+    )
+
+    mujoco_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [
+                    FindPackageShare("aerial_robot_simulation"),
+                    "launch",
+                    "mujoco_launch.py",
+                ]
+            )
+        ),
+        launch_arguments={
+            "robot_ns": robot_ns,
+            "headless": headless,
+            "mujoco_model": mujoco_model,
+            "mujoco_urdf_xacro": xacro_path,
+            "mujoco_xacro_options": model_options,
+            "viewer_font_scale": viewer_font_scale,
+            "sim_param_path": sim_param_path,
+            "spawn_x": spawn_x,
+            "spawn_y": spawn_y,
+            "spawn_z": spawn_z,
+        }.items(),
+        condition=IfCondition(sim_is_mujoco),
     )
 
     # ------------------------------------------------------------------
@@ -313,6 +350,7 @@ def generate_launch_description():
     ld.add_action(servo_bridge_node)
     ld.add_action(joint_position_spawner)
     ld.add_action(model_launch)
-    ld.add_action(sim_launch)
+    ld.add_action(gazebo_launch)
+    ld.add_action(mujoco_launch)
 
     return ld

--- a/robots/mini_quadrotor/urdf/robot.gazebo.xacro
+++ b/robots/mini_quadrotor/urdf/robot.gazebo.xacro
@@ -3,6 +3,7 @@
     xmlns:xacro="http://www.ros.org/wiki/xacro" name="mini_quadrotor" >
 
   <xacro:arg name="robot_name" default="mini_quadrotor" />
+  <xacro:arg name="rotor_visual_speed_rate" default="20.0" />
 
   <!-- robot urdf -->
   <xacro:include filename="$(find mini_quadrotor)/urdf/robot.urdf.xacro" />
@@ -25,6 +26,7 @@
     <hardware>
       <plugin>gz_ros2_control/AerialRobotHwSim</plugin>
       <param name="m_f_rate">${m_f_rate}</param>
+      <param name="rotor_visual_speed_rate">$(arg rotor_visual_speed_rate)</param>
     </hardware>
     <joint name="dummy_joint">
       <command_interface name="position">

--- a/robots/mini_quadrotor/urdf/robot.gazebo.xacro
+++ b/robots/mini_quadrotor/urdf/robot.gazebo.xacro
@@ -7,9 +7,24 @@
   <!-- robot urdf -->
   <xacro:include filename="$(find mini_quadrotor)/urdf/robot.urdf.xacro" />
 
+  <xacro:macro name="rotor_control_joint" params="id">
+    <joint name="rotor${id}">
+      <command_interface name="effort">
+        <param name="min">${min_force}</param>
+        <param name="max">${max_force}</param>
+      </command_interface>
+      <state_interface name="position">
+        <param name="initial_value">${0}</param>
+      </state_interface>
+      <state_interface name="velocity"/>
+      <state_interface name="effort"/>
+    </joint>
+  </xacro:macro>
+
   <ros2_control name="aerial_robot_sim_system" type="system">
     <hardware>
       <plugin>gz_ros2_control/AerialRobotHwSim</plugin>
+      <param name="m_f_rate">${m_f_rate}</param>
     </hardware>
     <joint name="dummy_joint">
       <command_interface name="position">
@@ -22,6 +37,10 @@
       <state_interface name="velocity"/>
       <state_interface name="effort"/>
     </joint>
+    <xacro:rotor_control_joint id="1"/>
+    <xacro:rotor_control_joint id="2"/>
+    <xacro:rotor_control_joint id="3"/>
+    <xacro:rotor_control_joint id="4"/>
     <sensor name="spinal_imu">
       <state_interface name="orientation.x"/>
       <state_interface name="orientation.y"/>

--- a/robots/mini_quadrotor/urdf/robot.urdf.xacro
+++ b/robots/mini_quadrotor/urdf/robot.urdf.xacro
@@ -5,6 +5,7 @@
   <!-- general attribute -->
   <baselink name="fc" />
   <thrust_link name="thrust" />
+  <xacro:arg name="rotor_joint_velocity_limit" default="10000.0" />
 
   <!-- kinematics [m] -->
   <xacro:property name="rotor_x" value="0.085" />
@@ -16,6 +17,7 @@
   <m_f_rate value="${m_f_rate}" />
   <xacro:property name="max_force" value="8.0" /> <!-- [N] -->
   <xacro:property name="min_force" value="0.0" /> <!-- [N] -->
+  <xacro:property name="rotor_joint_velocity_limit" value="$(arg rotor_joint_velocity_limit)" />
 
   <!-- friction -->
   <xacro:macro name="damping_factor" params="link">
@@ -45,7 +47,7 @@
 
   <xacro:macro name="propeller_module" params="id x y z direction">
     <joint name="rotor${id}" type="continuous">
-      <limit effort="100.0" lower="${min_force}" upper="${max_force}" velocity="0.5"/>
+      <limit effort="100.0" lower="${min_force}" upper="${max_force}" velocity="${rotor_joint_velocity_limit}"/>
       <parent link="main_body"/>
       <child link="thrust${id}"/>
       <origin rpy="0 0 0" xyz="${x} ${y} ${z}"/>

--- a/robots/mini_quadrotor/urdf/robot.urdf.xacro
+++ b/robots/mini_quadrotor/urdf/robot.urdf.xacro
@@ -12,7 +12,8 @@
   <xacro:property name="rotor_z" value="0.026" />
 
   <!-- dynamics -->
-  <m_f_rate value="-0.011" /> <!-- drag torque rate -->
+  <xacro:property name="m_f_rate" value="-0.011" /> <!-- drag torque rate -->
+  <m_f_rate value="${m_f_rate}" />
   <xacro:property name="max_force" value="8.0" /> <!-- [N] -->
   <xacro:property name="min_force" value="0.0" /> <!-- [N] -->
 


### PR DESCRIPTION
## What is this PR
This PR adds MuJoCo as an optional simulation backend alongside Gazebo. It introduces MuJoCo model generation from URDF/Xacro, a ROS 2 bridge for MuJoCo physics/sensors/actuators, and a standalone MuJoCo attitude controller while keeping the existing Gazebo simulation path working.

### Details
[Please explain the contribution of this PR in detail based on all commits it is made out of]:
- Adds MuJoCo launch, bridge, and standalone attitude controller nodes.
- Generates MuJoCo MJCF/XML models from URDF/Xacro when no XML is provided.